### PR TITLE
Amélioration des erreurs de validation

### DIFF
--- a/lib/models/__tests__/base-locale.schema.js
+++ b/lib/models/__tests__/base-locale.schema.js
@@ -89,4 +89,3 @@ test('not valid payload: not allowed extra param', t => {
 
   t.is(error.message, '"extra" is not allowed')
 })
-

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -2,7 +2,7 @@ const communes = require('@etalab/decoupage-administratif/data/communes.json')
 const Joi = require('joi')
 const {omit} = require('lodash')
 const {generateBase62String} = require('../util/base62')
-const {getFilteredPayload} = require('../util/payload')
+const {validPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {extract} = require('../populate/extract-ban')
 const Voie = require('./voie')
@@ -17,8 +17,7 @@ const createSchema = Joi.object().keys({
 })
 
 async function create(payload) {
-  const baseLocale = getFilteredPayload(payload, createSchema)
-  Joi.assert(baseLocale, createSchema)
+  const baseLocale = validPayload(payload, createSchema)
 
   baseLocale.token = generateBase62String(20)
   baseLocale.communes = []
@@ -41,8 +40,7 @@ const updateSchema = Joi.object().keys({
 })
 
 async function update(id, payload) {
-  const baseLocaleChanges = getFilteredPayload(payload, updateSchema)
-  Joi.assert(baseLocaleChanges, updateSchema)
+  const baseLocaleChanges = validPayload(payload, updateSchema)
 
   mongo.decorateModification(baseLocaleChanges)
 

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -1,6 +1,7 @@
 const Joi = require('joi')
 const {getFilteredPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
+const {validPayload} = require('../util/payload')
 const position = require('./position')
 
 const createSchema = Joi.object().keys({
@@ -12,8 +13,7 @@ const createSchema = Joi.object().keys({
 })
 
 async function create(idVoie, payload) {
-  const numero = getFilteredPayload(payload, createSchema)
-  Joi.assert(numero, createSchema)
+  const numero = validPayload(payload, createSchema)
 
   const voie = await mongo.db.collection('voies').findOne({_id: mongo.parseObjectID(idVoie)})
 
@@ -73,8 +73,7 @@ async function importMany(idBal, rawNumeros, options = {}) {
 }
 
 async function update(id, payload) {
-  const numeroChanges = getFilteredPayload(payload, updateSchema)
-  Joi.assert(numeroChanges, updateSchema)
+  const numeroChanges = validPayload(payload, updateSchema)
 
   mongo.decorateModification(numeroChanges)
 

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -1,6 +1,7 @@
 const Joi = require('joi')
 const {getFilteredPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
+const {validPayload} = require('../util/payload')
 const position = require('./position')
 
 function cleanNom(nom) {
@@ -19,8 +20,7 @@ async function create(idBal, codeCommune, payload) {
     payload.nom = cleanNom(payload.nom)
   }
 
-  const voie = getFilteredPayload(payload, createSchema)
-  Joi.assert(voie, createSchema)
+  const voie = validPayload(payload, createSchema)
 
   voie._bal = idBal
   voie.code = null
@@ -90,8 +90,7 @@ async function update(id, payload) {
     payload.nom = cleanNom(payload.nom)
   }
 
-  const voieChanges = getFilteredPayload(payload, updateSchema)
-  Joi.assert(voieChanges, updateSchema)
+  const voieChanges = validPayload(payload, updateSchema)
 
   mongo.decorateModification(voieChanges)
   const {value} = await mongo.db.collection('voies').findOneAndUpdate(

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -50,8 +50,15 @@ test.serial('create a BaseLocale', async t => {
 })
 
 test.serial('create a BaseLocale / invalid payload', async t => {
-  const {status} = await request(getApp()).post('/bases-locales').send({})
-  t.is(status, 500)
+  const {status, body} = await request(getApp()).post('/bases-locales').send({})
+  t.is(status, 400)
+  t.deepEqual(body, {
+    code: 400,
+    message: 'Invalid payload',
+    validation: {
+      emails: ['"emails" is required']
+    }
+  })
 })
 
 test.serial('get all BaseLocale', async t => {
@@ -173,6 +180,34 @@ test.serial('modify a BaseLocal / without admin token', async t => {
 
   const {status} = await request(getApp()).put(`/bases-locales/${_id}`).send({nom: 'bar'})
   t.is(status, 403)
+})
+
+test.serial('modify a BaseLocal / invalid payload', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    description: 'bar',
+    emails: ['me@domain.tld'],
+    communes: [],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status, body} = await request(getApp())
+    .put(`/bases-locales/${_id}`)
+    .set({Authorization: 'Token coucou'})
+    .send({emails: []})
+
+  t.is(status, 400)
+  t.deepEqual(body, {
+    code: 400,
+    message: 'Invalid payload',
+    validation: {
+      emails: ['"emails" must contain at least 1 items']
+    }
+  })
 })
 
 test.serial('delete a BaseLocal / with admin token', async t => {

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -98,12 +98,19 @@ test.serial('create a numero / invalid payload', async t => {
     _updated: new Date('2019-01-01')
   })
 
-  const {status} = await request(getApp())
+  const {status, body} = await request(getApp())
     .post(`/voies/${_idVoie}/numeros`)
     .set({Authorization: 'Token coucou'})
     .send({numero: 'invalid numero'})
 
-  t.is(status, 500)
+  t.is(status, 400)
+  t.deepEqual(body, {
+    code: 400,
+    message: 'Invalid payload',
+    validation: {
+      numero: ['"numero" must be a number']
+    }
+  })
 })
 
 test.serial('create a numero / invalid voie', async t => {
@@ -367,12 +374,19 @@ test.serial('modify a numero / invalid payload', async t => {
     _updated: new Date('2019-01-01')
   })
 
-  const {status} = await request(getApp())
+  const {status, body} = await request(getApp())
     .put(`/numeros/${_id}`)
     .set({Authorization: 'Token coucou'})
     .send({numero: 'invalid numero'})
 
-  t.is(status, 500)
+  t.is(status, 400)
+  t.deepEqual(body, {
+    code: 400,
+    message: 'Invalid payload',
+    validation: {
+      numero: ['"numero" must be a number']
+    }
+  })
 })
 test.serial('modify a numero / without admin token', async t => {
   const _idVoie = new mongo.ObjectID()

--- a/lib/routes/__tests__/voies.js
+++ b/lib/routes/__tests__/voies.js
@@ -118,12 +118,19 @@ test.serial('create a voie / invalid voie', async t => {
     _updated: new Date('2019-01-01')
   })
 
-  const {status} = await request(getApp())
+  const {status, body} = await request(getApp())
     .post(`/bases-locales/${_id}/communes/12345/voies`)
     .set({Authorization: 'Token coucou'})
     .send({})
 
-  t.is(status, 500)
+  t.is(status, 400)
+  t.deepEqual(body, {
+    code: 400,
+    message: 'Invalid payload',
+    validation: {
+      nom: ['"nom" is required']
+    }
+  })
 })
 
 test.serial('create a voie / without admin token', async t => {
@@ -377,12 +384,19 @@ test.serial('modify a voie / invalid payload', async t => {
     _updated: new Date('2019-01-01')
   })
 
-  const {status} = await request(getApp())
+  const {status, body} = await request(getApp())
     .put(`/voies/${_id}`)
     .set({Authorization: 'Token coucou'})
     .send({code: 'invalid code'})
 
-  t.is(status, 500)
+  t.is(status, 400)
+  t.deepEqual(body, {
+    code: 400,
+    message: 'Invalid payload',
+    validation: {
+      code: ['"code" with value "invalid code" fails to match the required pattern: /^[0-9A-Z]\\d{3}$/']
+    }
+  })
   const voie = await mongo.db.collection('voies').findOne({_id})
   t.is(voie.code, null)
 })

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -3,6 +3,7 @@ const w = require('../util/w')
 const BaseLocale = require('../models/base-locale')
 const Voie = require('../models/voie')
 const Numero = require('../models/numero')
+const {ValidationError} = require('../util/payload')
 
 const app = new express.Router()
 
@@ -158,5 +159,18 @@ app.route('/numeros/:numeroId')
     await Numero.remove(req.numero._id)
     res.sendStatus(204)
   }))
+
+app.use((err, req, res, next) => {
+  if (err) {
+    if (err instanceof ValidationError) {
+      const {message, validation} = err
+      res.status(400).send({code: 400, message, validation})
+    }
+
+    res.status(500).send({code: 500, message: err.message})
+  }
+
+  next()
+})
 
 module.exports = app

--- a/lib/util/payload.js
+++ b/lib/util/payload.js
@@ -1,8 +1,40 @@
+const Joi = require('joi')
 const {pick} = require('lodash')
+
+class ValidationError extends Error {
+  constructor(validationDetails) {
+    super('Invalid payload')
+    this.validation = validationDetails.reduce((acc, detail) => {
+      const key = detail.path[0]
+      if (!acc[key]) {
+        acc[key] = []
+      }
+
+      acc[key].push(detail.message)
+      return acc
+    }, {})
+  }
+}
 
 function getFilteredPayload(payload, schema) {
   const acceptableKeys = Object.keys(schema.describe().children)
   return pick(payload, acceptableKeys)
 }
 
-module.exports = {getFilteredPayload}
+function validPayload(payload, schema) {
+  const filteredPayload = getFilteredPayload(payload, schema)
+
+  const {error} = Joi.validate(filteredPayload, schema, {abortEarly: false})
+
+  if (error) {
+    throw new ValidationError(error.details)
+  }
+
+  return filteredPayload
+}
+
+module.exports = {
+  getFilteredPayload,
+  validPayload,
+  ValidationError
+}

--- a/lib/util/payload.test.js
+++ b/lib/util/payload.test.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 const Joi = require('joi')
-const {getFilteredPayload} = require('./payload')
+const {getFilteredPayload, validPayload, ValidationError} = require('./payload')
 
 test('filter payload for create baselocal schema', t => {
   const schema = Joi.object().keys({
@@ -14,4 +14,32 @@ test('filter payload for create baselocal schema', t => {
   const filteredPayload = getFilteredPayload(payload, schema)
 
   t.deepEqual(filteredPayload, {foo: 'bar'})
+})
+
+test('check a valid payload', t => {
+  const schema = Joi.object().keys({
+    foo: Joi.string()
+  })
+  const payload = {
+    foo: 'foo'
+  }
+
+  t.notThrows(() => validPayload(payload, schema))
+})
+
+test('check a invalid payload', t => {
+  const payload = {bar: ''}
+  const schema = Joi.object().keys({
+    foo: Joi.string().required(),
+    bar: Joi.string().min(1)
+  })
+
+  const error = t.throws(() => {
+    validPayload(payload, schema)
+  }, ValidationError)
+
+  t.deepEqual(error.validation, {
+    foo: ['"foo" is required'],
+    bar: ['"bar" is not allowed to be empty', '"bar" length must be at least 1 characters long']
+  })
 })


### PR DESCRIPTION
Actuellement une erreur de validation provoque une `erreur 500`.
Désormais l'API renvoi une `erreur 400` avec le détails des erreurs de validation sous la forme suivante:

```
{
  code: 400,
  message: 'Invalid payload',
  validation: {
    foo: ['err1', 'err2'],
    bar: ['err']
  }
}
```