### PR TITLE
Modification du comportement de la validation

### DIFF
--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -45,6 +45,15 @@ test('create a numero', async t => {
   t.deepEqual(numero._created, voie._updated)
 })
 
+test('create a numero / invalid numero type', t => {
+  const idVoie = new mongo.ObjectID()
+  return t.throwsAsync(Numero.create(idVoie, {
+    numero: '042',
+    suffixe: 'foo',
+    positions: []
+  }), 'Invalid payload')
+})
+
 test('create a numero / minimal', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('voies').insertOne({_id})

--- a/lib/util/__tests__/payload.js
+++ b/lib/util/__tests__/payload.js
@@ -28,10 +28,11 @@ test('check a valid payload', t => {
 })
 
 test('check a invalid payload', t => {
-  const payload = {bar: ''}
+  const payload = {bar: '', toto: '1'}
   const schema = Joi.object().keys({
     foo: Joi.string().required(),
-    bar: Joi.string().min(1)
+    bar: Joi.string().min(1),
+    toto: Joi.number().required()
   })
 
   const error = t.throws(() => {
@@ -40,6 +41,7 @@ test('check a invalid payload', t => {
 
   t.deepEqual(error.validation, {
     foo: ['"foo" is required'],
-    bar: ['"bar" is not allowed to be empty', '"bar" length must be at least 1 characters long']
+    bar: ['"bar" is not allowed to be empty', '"bar" length must be at least 1 characters long'],
+    toto: ['"toto" must be a number']
   })
 })

--- a/lib/util/payload.js
+++ b/lib/util/payload.js
@@ -24,7 +24,8 @@ function getFilteredPayload(payload, schema) {
 function validPayload(payload, schema) {
   const {error, value} = Joi.validate(payload, schema, {
     abortEarly: false,
-    stripUnknown: true
+    stripUnknown: true,
+    convert: false
   })
 
   if (error) {

--- a/lib/util/payload.js
+++ b/lib/util/payload.js
@@ -22,15 +22,16 @@ function getFilteredPayload(payload, schema) {
 }
 
 function validPayload(payload, schema) {
-  const filteredPayload = getFilteredPayload(payload, schema)
-
-  const {error} = Joi.validate(filteredPayload, schema, {abortEarly: false})
+  const {error, value} = Joi.validate(payload, schema, {
+    abortEarly: false,
+    stripUnknown: true
+  })
 
   if (error) {
     throw new ValidationError(error.details)
   }
 
-  return filteredPayload
+  return value
 }
 
 module.exports = {


### PR DESCRIPTION
- Plus de magic casting : le type attendu doit être respecté
- Joi permet déjà de filter les clés reconnues

L'implémentation précédente laisser passer les valeurs dont le type pouvait être casté, mais enregistrait la mauvaise version.