### PR TITLE
Run api in development mode in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,5 +33,6 @@ services:
     environment:
       MONGODB_URL: mongodb://mongo:27017
       MONGODB_DBNAME: api-bal
+      NODE_ENV: development
     ports:
       - 5000:5000


### PR DESCRIPTION
So it doesn’t warn about SMTP settings.