### PR TITLE
Ajoute les commentaires au schéma Numero

### DIFF
--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -31,12 +31,13 @@ test('create a numero', async t => {
   const numero = await Numero.create(_id, {
     numero: 42,
     suffixe: 'foo',
+    comment: 'bar',
     positions: []
   })
 
-  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'positions']
+  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'comment', 'positions']
   t.true(keys.every(k => k in numero))
-  t.is(Object.keys(numero).length, 9)
+  t.is(Object.keys(numero).length, 10)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
   t.deepEqual(numero._created, bal._updated)

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -37,7 +37,7 @@ test('create a numero', async t => {
 
   const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'comment', 'positions']
   t.true(keys.every(k => k in numero))
-  t.is(Object.keys(numero).length, 10)
+  t.is(Object.keys(numero).length, keys.length)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
   t.deepEqual(numero._created, bal._updated)
@@ -60,9 +60,9 @@ test('create a numero / minimal', async t => {
   await mongo.db.collection('voies').insertOne({_id})
   const numero = await Numero.create(_id, {numero: 42})
 
-  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'positions']
+  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'positions', 'comment']
   t.true(keys.every(k => k in numero))
-  t.is(Object.keys(numero).length, 9)
+  t.is(Object.keys(numero).length, keys.length)
 })
 
 test('create a numero / voie do not exists', t => {

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -118,6 +118,7 @@ test('update a numero', async t => {
   const numero = await Numero.update(_id, {
     numero: 24,
     suffixe: 'bar',
+    comment: 'Commentaire de numéro 123 !',
     positions: [{
       point: {type: 'Point', coordinates: [0, 0]},
       source: 'source',
@@ -127,8 +128,9 @@ test('update a numero', async t => {
 
   t.is(numero.numero, 24)
   t.is(numero.suffixe, 'bar')
+  t.is(numero.comment, 'Commentaire de numéro 123 !')
   t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 9)
+  t.is(Object.keys(numero).length, 10)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
   t.notDeepEqual(numero._created, bal._updated)

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -7,6 +7,7 @@ const position = require('./position')
 const createSchema = Joi.object().keys({
   numero: Joi.number().min(0).max(9999).integer().required(),
   suffixe: Joi.string().regex(/^[a-z][a-z0-9]*$/).max(10).allow(null),
+  comment: Joi.string().max(5000).allow(null),
   positions: Joi.array().items(
     Joi.lazy(() => position.createSchema).description('position schema')
   )

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -28,6 +28,7 @@ async function create(idVoie, payload) {
 
   numero.suffixe = numero.suffixe || null
   numero.positions = numero.positions || []
+  numero.comment = numero.comment || null
 
   mongo.decorateCreation(numero)
 

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -86,6 +86,7 @@ async function importMany(idBal, rawNumeros, options = {}) {
 const updateSchema = Joi.object().keys({
   numero: Joi.number().min(0).max(9999).integer(),
   suffixe: Joi.string().regex(/^[a-z][a-z0-9]*$/).max(10).allow(null),
+  comment: Joi.string().max(5000).allow(null),
   positions: Joi.array().items(
     Joi.lazy(() => position.createSchema).description('position schema')
   )

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -7,7 +7,7 @@ const mongo = require('../../util/mongo')
 const routes = require('..')
 
 const GENERATED_VARS = ['_id', '_updated', '_created']
-const KEYS = ['_id', '_bal', 'commune', 'voie', 'numero', 'numeroComplet', 'positions', 'suffixe', '_created', '_updated']
+const KEYS = ['_id', '_bal', 'commune', 'voie', 'numero', 'numeroComplet', 'positions', 'suffixe', '_created', '_updated', 'comment']
 
 test.before('start server', async () => {
   MongoDBServer.port = 27023 // Temp fix
@@ -69,7 +69,8 @@ test.serial('create a numero', async t => {
     numero: 42,
     numeroComplet: '42',
     suffixe: null,
-    positions: []
+    positions: [],
+    comment: null
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)
@@ -185,6 +186,7 @@ test.serial('get all numeros from a voie', async t => {
     numero: 42,
     suffixe: null,
     positions: [],
+    comment: null,
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -235,6 +237,7 @@ test.serial('get a numero', async t => {
     numero: 42,
     suffixe: 'bis',
     positions: [],
+    comment: null,
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -250,7 +253,8 @@ test.serial('get a numero', async t => {
     numero: 42,
     suffixe: 'bis',
     numeroComplet: '42bis',
-    positions: []
+    positions: [],
+    comment: null
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)
@@ -295,6 +299,7 @@ test.serial('modify a numero', async t => {
     numero: 42,
     suffixe: null,
     positions: [],
+    comment: null,
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -372,6 +377,7 @@ test.serial('modify a numero / invalid payload', async t => {
     numero: 42,
     suffixe: null,
     positions: [],
+    comment: null,
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -422,6 +428,7 @@ test.serial('modify a numero / without admin token', async t => {
     numero: 42,
     suffixe: null,
     positions: [],
+    comment: null,
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -467,6 +474,7 @@ test.serial('delete a numero', async t => {
     numero: 42,
     suffixe: null,
     positions: [],
+    comment: null,
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -519,6 +527,7 @@ test.serial('delete a numero / without admin token', async t => {
     numero: 42,
     suffixe: null,
     positions: [],
+    comment: null,
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })


### PR DESCRIPTION
Ce nouveau champs n'existe pas à la création d'un numéro mais peut être ajouté lors d'une modification.

Il peut être à `null` mais de peut dépasser 5000 caractères.