### PR TITLE
Ajout d'un statut au modèle base locale

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -23,6 +23,7 @@ test('create a BaseLocale', async t => {
   })
   const keys = ['nom', 'description', 'status', 'emails', 'token', '_updated', '_created', '_id', 'communes']
   t.true(keys.every(k => k in baseLocale))
+  t.true(baseLocale.status === 'draft')
   t.is(Object.keys(baseLocale).length, 9)
 })
 
@@ -61,6 +62,7 @@ test('update a BaseLocale', async t => {
   t.is(baseLocale.description, 'bar2')
   t.is(baseLocale.emails[0], 'me2@domain.tld')
   t.is(baseLocale.token, 'coucou')
+  t.is(baseLocale.status, 'ready-to-publish')
   t.is(Object.keys(baseLocale).length, 9)
 })
 

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -21,18 +21,18 @@ test('create a BaseLocale', async t => {
     description: 'bar',
     emails: ['me@domain.tld']
   })
-  const keys = ['nom', 'description', 'emails', 'token', '_updated', '_created', '_id', 'communes']
+  const keys = ['nom', 'description', 'status', 'emails', 'token', '_updated', '_created', '_id', 'communes']
   t.true(keys.every(k => k in baseLocale))
-  t.is(Object.keys(baseLocale).length, 8)
+  t.is(Object.keys(baseLocale).length, 9)
 })
 
 test('create a BaseLocale / minimal', async t => {
   const baseLocale = await BaseLocale.create({
     emails: ['me@domain.tld']
   })
-  const keys = ['nom', 'description', 'emails', 'token', '_updated', '_created', '_id', 'communes']
+  const keys = ['nom', 'description', 'status', 'emails', 'token', '_updated', '_created', '_id', 'communes']
   t.true(keys.every(k => k in baseLocale))
-  t.is(Object.keys(baseLocale).length, 8)
+  t.is(Object.keys(baseLocale).length, 9)
 })
 
 test('update a BaseLocale', async t => {
@@ -44,6 +44,7 @@ test('update a BaseLocale', async t => {
     emails: ['me@domain.tld'],
     communes: [],
     token: 'coucou',
+    status: 'draft',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -52,6 +53,7 @@ test('update a BaseLocale', async t => {
     nom: 'foo2',
     description: 'bar2',
     emails: ['me2@domain.tld'],
+    status: 'ready-to-publish',
     token: 'hack'
   })
 
@@ -59,7 +61,7 @@ test('update a BaseLocale', async t => {
   t.is(baseLocale.description, 'bar2')
   t.is(baseLocale.emails[0], 'me2@domain.tld')
   t.is(baseLocale.token, 'coucou')
-  t.is(Object.keys(baseLocale).length, 8)
+  t.is(Object.keys(baseLocale).length, 9)
 })
 
 test('update a BaseLocale / not found', t => {

--- a/lib/models/__tests__/base-locale.schema.js
+++ b/lib/models/__tests__/base-locale.schema.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 const Joi = require('joi')
-const {createSchema} = require('../base-locale')
+const {createSchema, updateSchema} = require('../base-locale')
 
 test('valid payload', t => {
   const baseLocale = {
@@ -88,4 +88,14 @@ test('not valid payload: not allowed extra param', t => {
   const {error} = Joi.validate(baseLocale, createSchema)
 
   t.is(error.message, '"extra" is not allowed')
+})
+
+test('not valid payload: invalid status', t => {
+  const baseLocale = {
+    status: 'invalid-status'
+  }
+
+  const {error} = Joi.validate(baseLocale, updateSchema)
+
+  t.true(error.message.includes('child "status" fails because ["status" must be one of [draft, ready-to-publish]]'))
 })

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -29,6 +29,7 @@ async function create(payload) {
   baseLocale.communes = []
   baseLocale.nom = baseLocale.nom || null
   baseLocale.description = baseLocale.description || null
+  baseLocale.status = 'draft'
 
   mongo.decorateCreation(baseLocale)
 
@@ -44,6 +45,7 @@ async function create(payload) {
 const updateSchema = Joi.object().keys({
   nom: Joi.string().max(200).allow(null),
   description: Joi.string().max(2000).allow(null),
+  status: Joi.string().valid(['draft', 'ready-to-publish']),
   emails: Joi.array().min(1).items(
     Joi.string().email()
   )

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -29,8 +29,8 @@ function getApp() {
   return app
 }
 
-const GENERATED_VARS = ['_id', '_updated', '_created', 'token']
-const KEYS = ['nom', 'description', 'emails', 'token', '_updated', '_created', '_id', 'communes']
+const GENERATED_VARS = ['_id', '_updated', '_created', 'token', 'status']
+const KEYS = ['nom', 'description', 'emails', 'token', '_updated', '_created', '_id', 'communes', 'status']
 const SAFE_FIELDS = ['nom', 'description', '_updated', '_created', '_id', 'communes']
 
 test.serial('create a BaseLocale', async t => {
@@ -105,6 +105,7 @@ test.serial('get a BaseLocal / with admin token', async t => {
     description: 'bar',
     emails: ['me@domain.tld'],
     communes: [],
+    status: 'draft',
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -29,7 +29,7 @@ function getApp() {
   return app
 }
 
-const GENERATED_VARS = ['_id', '_updated', '_created', 'token', 'status']
+const GENERATED_VARS = ['_id', '_updated', '_created', 'token']
 const KEYS = ['nom', 'description', 'emails', 'token', '_updated', '_created', '_id', 'communes', 'status']
 const SAFE_FIELDS = ['nom', 'description', '_updated', '_created', '_id', 'communes']
 
@@ -45,6 +45,7 @@ test.serial('create a BaseLocale', async t => {
     nom: 'foo',
     description: 'bar',
     emails: ['me@domain.tld'],
+    status: 'draft',
     communes: []
   })
   t.true(KEYS.every(k => k in body))


### PR DESCRIPTION
Nouvelle propriété `status` qui peut avoir les valeurs suivantes:
- "draft"
- "ready-to-publish"

Par défaut cette propriété est équal à "draft" lors de la création d'une base locale. 

Fix #86 