### PR TITLE
Fix throws tests

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -68,7 +68,7 @@ test('update a BaseLocale', async t => {
 
 test('update a BaseLocale / not found', t => {
   const _id = new mongo.ObjectID()
-  return t.throwsAsync(() => BaseLocale.update(_id, {nom: 'foo'}), 'BaseLocale not found')
+  return t.throwsAsync(() => BaseLocale.update(_id, {nom: 'foo'}), {message: 'BaseLocale not found'})
 })
 
 test('remove a BaseLocale', async t => {

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -52,7 +52,7 @@ test('create a numero / invalid numero type', t => {
     numero: '042',
     suffixe: 'foo',
     positions: []
-  }), 'Invalid payload')
+  }), {message: 'Invalid payload'})
 })
 
 test('create a numero / minimal', async t => {
@@ -75,7 +75,7 @@ test('create a numero with uppercase suffixe', async t => {
 
 test('create a numero / voie do not exists', t => {
   const _id = new mongo.ObjectID()
-  return t.throwsAsync(Numero.create(_id, {numero: 42}, 'Voie not found'))
+  return t.throwsAsync(Numero.create(_id, {numero: 42}, {message: 'Voie not found'}))
 })
 
 test('importMany', async t => {
@@ -150,7 +150,7 @@ test('update a numero', async t => {
 
 test('update a numero / not found', t => {
   const _id = new mongo.ObjectID()
-  return t.throwsAsync(() => Numero.update(_id, {numero: 42}), 'Numero not found')
+  return t.throwsAsync(() => Numero.update(_id, {numero: 42}), {message: 'Numero not found'})
 })
 
 test('delete a numero', async t => {

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -135,7 +135,7 @@ test('update a Voie', async t => {
 
 test('update a Voie / not found', t => {
   const _id = new mongo.ObjectID()
-  return t.throwsAsync(() => Voie.update(_id, {nom: 'bar'}), 'Voie not found')
+  return t.throwsAsync(() => Voie.update(_id, {nom: 'bar'}), {message: 'Voie not found'})
 })
 
 test('remove a Voie', async t => {

--- a/lib/util/__tests__/payload.js
+++ b/lib/util/__tests__/payload.js
@@ -37,7 +37,7 @@ test('check a invalid payload', t => {
 
   const error = t.throws(() => {
     validPayload(payload, schema)
-  }, ValidationError)
+  }, {instanceOf: ValidationError})
 
   t.deepEqual(error.validation, {
     foo: ['"foo" is required'],


### PR DESCRIPTION
Corrige le deuxième paramètre envoyé à `t.throws` et `t.throwsAsync`