### PR TITLE
Ajout de typeNumerotation et trace au modèle Voie

### DIFF
--- a/lib/export/geojson.js
+++ b/lib/export/geojson.js
@@ -72,10 +72,10 @@ async function transformToGeoJSON({voiesCursor, numerosCursor}) {
   voies.forEach(v => {
     const {positions, typeNumerotation, trace} = v
     if (positions && positions.length > 0) {
-      geojsonStream.write(voieToToponymeFeature(v))
+      return geojsonStream.write(voieToToponymeFeature(v))
     }
 
-    if (typeNumerotation === 'metric' && trace) {
+    if (typeNumerotation === 'metrique' && trace) {
       geojsonStream.write(voieToLineFeature(v))
     }
   })

--- a/lib/export/geojson.js
+++ b/lib/export/geojson.js
@@ -22,6 +22,24 @@ function voieToToponymeFeature(v) {
   }
 }
 
+function voieToLineFeature(v) {
+  const properties = {
+    type: 'voie-trace',
+    nom: v.nom,
+    idVoie: v._id
+  }
+
+  if (v.complement) {
+    properties.complement = v.complement
+  }
+
+  return {
+    type: 'Feature',
+    geometry: v.trace ? v.trace.geometry : null,
+    properties
+  }
+}
+
 function numeroVoieToAdresseFeature(n, v) {
   const position = n.positions[0]
   const properties = {
@@ -52,8 +70,13 @@ async function transformToGeoJSON({voiesCursor, numerosCursor}) {
   const geojsonStream = stringify()
 
   voies.forEach(v => {
-    if (v.positions && v.positions.length > 0) {
+    const {positions, typeNumerotation, trace} = v
+    if (positions && positions.length > 0) {
       geojsonStream.write(voieToToponymeFeature(v))
+    }
+
+    if (typeNumerotation === 'metric' && trace) {
+      geojsonStream.write(voieToLineFeature(v))
     }
   })
 

--- a/lib/export/geojson.js
+++ b/lib/export/geojson.js
@@ -35,7 +35,7 @@ function voieToLineFeature(v) {
 
   return {
     type: 'Feature',
-    geometry: v.trace ? v.trace.geometry : null,
+    geometry: v.trace,
     properties
   }
 }

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -29,7 +29,7 @@ test('create a Voie', async t => {
   t.is(voie.nom, 'foo oo')
   t.is(voie.complement, null)
   t.deepEqual(voie.positions, [])
-  t.is(voie.typeNumerotation, 'numeric')
+  t.is(voie.typeNumerotation, 'numerique')
   t.is(voie.trace, null)
   t.truthy(voie._created)
   t.truthy(voie._updated)

--- a/lib/models/__tests__/voie.mongo.js
+++ b/lib/models/__tests__/voie.mongo.js
@@ -29,10 +29,12 @@ test('create a Voie', async t => {
   t.is(voie.nom, 'foo oo')
   t.is(voie.complement, null)
   t.deepEqual(voie.positions, [])
+  t.is(voie.typeNumerotation, 'numeric')
+  t.is(voie.trace, null)
   t.truthy(voie._created)
   t.truthy(voie._updated)
 
-  t.is(Object.keys(voie).length, 9)
+  t.is(Object.keys(voie).length, 11)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id})
   t.deepEqual(voie._created, bal._updated)

--- a/lib/models/__tests__/voie.schema.js
+++ b/lib/models/__tests__/voie.schema.js
@@ -67,6 +67,17 @@ test('not valid payload: complement over 200 caracters', t => {
   t.true(error.message.includes('"complement" length must be less than or equal to 200 characters long'))
 })
 
+test('not valid payload: invalid typeNumerotation', t => {
+  const voie = {
+    nom: 'voie',
+    typeNumerotation: 'invalid type'
+  }
+
+  const {error} = createSchema.validate(voie)
+
+  t.truthy(error)
+})
+
 test('cleanNom', t => {
   t.is(cleanNom(' Allée des   peupliers '), 'Allée des peupliers')
 })

--- a/lib/models/__tests__/voie.schema.js
+++ b/lib/models/__tests__/voie.schema.js
@@ -37,6 +37,20 @@ test('valid payload: with complement', t => {
   t.is(error, undefined)
 })
 
+test('valid payload: with trace', t => {
+  const voie = {
+    nom: 'voie',
+    trace: {
+      type: 'LineString',
+      coordinates: []
+    }
+  }
+
+  const {error} = createSchema.validate(voie)
+
+  t.is(error, undefined)
+})
+
 test('not valid payload: nom missing', t => {
   const {error} = createSchema.validate({})
 
@@ -71,6 +85,20 @@ test('not valid payload: invalid typeNumerotation', t => {
   const voie = {
     nom: 'voie',
     typeNumerotation: 'invalid type'
+  }
+
+  const {error} = createSchema.validate(voie)
+
+  t.truthy(error)
+})
+
+test('not valid payload: invalid trace', t => {
+  const voie = {
+    nom: 'voie',
+    trace: {
+      type: 'line',
+      coordinates: {}
+    }
   }
 
   const {error} = createSchema.validate(voie)

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -14,7 +14,7 @@ const createSchema = Joi.object().keys({
     position.createSchema
   ),
   complement: Joi.string().max(200).allow(null),
-  typeNumerotation: Joi.string().valid('numeric', 'metric'),
+  typeNumerotation: Joi.string().valid('numerique', 'metrique'),
   trace: Joi.object().allow(null)
 })
 
@@ -30,7 +30,7 @@ async function create(idBal, codeCommune, payload) {
   voie.commune = codeCommune
   voie.positions = voie.positions || []
   voie.complement = voie.complement || null
-  voie.typeNumerotation = voie.typeNumerotation || 'numeric'
+  voie.typeNumerotation = voie.typeNumerotation || 'numerique'
   voie.trace = voie.trace || null
 
   mongo.decorateCreation(voie)
@@ -99,7 +99,7 @@ const updateSchema = Joi.object().keys({
     position.createSchema
   ),
   complement: Joi.string().max(200).allow(null),
-  typeNumerotation: Joi.string().valid('numeric', 'metric'),
+  typeNumerotation: Joi.string().valid('numerique', 'metrique'),
   trace: Joi.object().allow(null)
 })
 

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -13,7 +13,9 @@ const createSchema = Joi.object().keys({
   positions: Joi.array().items(
     position.createSchema
   ),
-  complement: Joi.string().max(200).allow(null)
+  complement: Joi.string().max(200).allow(null),
+  typeNumerotation: Joi.string().valid('numeric', 'metric'),
+  trace: Joi.object().allow(null)
 })
 
 async function create(idBal, codeCommune, payload) {
@@ -28,6 +30,8 @@ async function create(idBal, codeCommune, payload) {
   voie.commune = codeCommune
   voie.positions = voie.positions || []
   voie.complement = voie.complement || null
+  voie.typeNumerotation = voie.typeNumerotation || 'numeric'
+  voie.trace = voie.trace || null
 
   mongo.decorateCreation(voie)
 
@@ -94,7 +98,9 @@ const updateSchema = Joi.object().keys({
   positions: Joi.array().items(
     position.createSchema
   ),
-  complement: Joi.string().max(200).allow(null)
+  complement: Joi.string().max(200).allow(null),
+  typeNumerotation: Joi.string().valid('numeric', 'metric'),
+  trace: Joi.object().allow(null)
 })
 
 async function update(id, payload) {

--- a/lib/models/voie.js
+++ b/lib/models/voie.js
@@ -15,7 +15,10 @@ const createSchema = Joi.object().keys({
   ),
   complement: Joi.string().max(200).allow(null),
   typeNumerotation: Joi.string().valid('numerique', 'metrique'),
-  trace: Joi.object().allow(null)
+  trace: Joi.object({
+    type: Joi.string().valid('LineString').required(),
+    coordinates: Joi.array().required()
+  }).allow(null)
 })
 
 async function create(idBal, codeCommune, payload) {
@@ -100,7 +103,10 @@ const updateSchema = Joi.object().keys({
   ),
   complement: Joi.string().max(200).allow(null),
   typeNumerotation: Joi.string().valid('numerique', 'metrique'),
-  trace: Joi.object().allow(null)
+  trace: Joi.object({
+    type: Joi.string().valid('LineString').required(),
+    coordinates: Joi.array().required()
+  }).allow(null)
 })
 
 async function update(id, payload) {

--- a/lib/routes/__tests__/voies.js
+++ b/lib/routes/__tests__/voies.js
@@ -7,7 +7,7 @@ const mongo = require('../../util/mongo')
 const routes = require('..')
 
 const GENERATED_VARS = ['_id', '_updated', '_created']
-const KEYS = ['_id', '_bal', 'commune', 'nom', 'positions', 'code', '_created', '_updated', 'complement']
+const KEYS = ['_id', '_bal', 'commune', 'nom', 'positions', 'code', '_created', '_updated', 'complement', 'typeNumerotation', 'trace']
 
 const mongod = new MongoMemoryServer()
 
@@ -57,7 +57,9 @@ test.serial('create a voie', async t => {
     code: null,
     complement: null,
     commune: '12345',
-    positions: []
+    positions: [],
+    typeNumerotation: 'numeric',
+    trace: null
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)

--- a/lib/routes/__tests__/voies.js
+++ b/lib/routes/__tests__/voies.js
@@ -58,7 +58,7 @@ test.serial('create a voie', async t => {
     complement: null,
     commune: '12345',
     positions: [],
-    typeNumerotation: 'numeric',
+    typeNumerotation: 'numerique',
     trace: null
   })
   t.true(KEYS.every(k => k in body))


### PR DESCRIPTION
L'ajout des champs `typeNumerotation` et `trace` au modèle `Voie` permettent la création de voies avec une numérotation métrique.