### PR TITLE
Mise à jour liée au changement du nom de domaine

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,6 +9,6 @@ SMTP_SECURE=
 SMTP_FROM=
 SMTP_BCC=
 SHOW_EMAILS=YES
-EDITOR_URL_PATTERN=https://editeur.adresse.data.gouv.fr/bal/<id>/<token>
+EDITOR_URL_PATTERN=https://mes-adresses.data.gouv.fr/bal/<id>/<token>
 BAN_SOURCE_URL_PATTERN=https://adresse.data.gouv.fr/data/ban/adresses-odbl/latest/csv/adresses-<codeDepartement>.csv.gz
 API_URL=http://localhost:5000

--- a/lib/emails/bal-creation-notification.js
+++ b/lib/emails/bal-creation-notification.js
@@ -85,7 +85,7 @@ const bodyTemplate = template(`
     <p class="infos">
       <small>
         <i>Jeton d’administration (information expert)&nbsp;: <%= baseLocale.token %></i>
-        <div>Si ce lien ne fonctionne pas, collez cette URL dans la barre d’adresse de votre navigateur : <b><%= editorUrl %></b></div>
+        <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b><%= editorUrl %></b></div>
       </small>
     </p>
   </div>

--- a/lib/emails/bal-creation-notification.js
+++ b/lib/emails/bal-creation-notification.js
@@ -82,7 +82,12 @@ const bodyTemplate = template(`
     <p>En cas de problème, l'accès à la <b><i>Base Adresse Locale</i></b> peut être réinitialisé sur demande.</p>
 
     <span><i>L’équipe adresse.data.gouv.fr</i></span>
-    <p class="infos"><small><i>Jeton d’administration (information expert)&nbsp;: <%= baseLocale.token %></i></small></p>
+    <p class="infos">
+      <small>
+        <i>Jeton d’administration (information expert)&nbsp;: <%= baseLocale.token %></i>
+        <div>Si ce lien ne fonctionne pas collez cette URL dans la barre d'adresse de votre navigateur : <b><%= editorUrl %></b></div>
+      </small>
+    </p>
   </div>
 </body>
 

--- a/lib/emails/bal-creation-notification.js
+++ b/lib/emails/bal-creation-notification.js
@@ -85,7 +85,7 @@ const bodyTemplate = template(`
     <p class="infos">
       <small>
         <i>Jeton d’administration (information expert)&nbsp;: <%= baseLocale.token %></i>
-        <div>Si ce lien ne fonctionne pas collez cette URL dans la barre d'adresse de votre navigateur : <b><%= editorUrl %></b></div>
+        <div>Si ce lien ne fonctionne pas, collez cette URL dans la barre d’adresse de votre navigateur : <b><%= editorUrl %></b></div>
       </small>
     </p>
   </div>


### PR DESCRIPTION
- `editeur.adresse.data.gouv.fr` devient `mes-adresses.data.gouv.fr`
- Ajout d'un lien visible vers la Base Adresse Locale nouvellement créée afin d'éviter le blocage des liens depuis certaines boites mails.