### PR TITLE
Amélioration de la gestion des réponses lors d'une recherche par département

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -206,7 +206,7 @@ test('populate a commune', async t => {
   t.is((await mongo.db.collection('numeros').distinct('voie', {_bal: _id, commune: '54084'})).length, 20)
 })
 
-test('find Bases Locales by code departement', async t => {
+test('find Bases Locales by codes communes', async t => {
   const _idBalA = new mongo.ObjectID()
   const _idBalB = new mongo.ObjectID()
   const _idBalC = new mongo.ObjectID()
@@ -229,12 +229,12 @@ test('find Bases Locales by code departement', async t => {
     communes: ['48678']
   })
 
-  const basesLocales = await BaseLocale.fetchByCodeDepartement(47)
+  const basesLocales = await BaseLocale.fetchByCommunes(['47192', '47178', '47098'])
 
   t.deepEqual(basesLocales.map(({_id}) => _id), [_idBalA, _idBalB])
 })
 
-test('find Bases Locales by code departement / invalid code', async t => {
+test('find Bases Locales by codes communes / no BAL found', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('bases_locales').insertOne({
     _id,
@@ -242,5 +242,7 @@ test('find Bases Locales by code departement / invalid code', async t => {
     communes: ['54084']
   })
 
-  return t.throwsAsync(() => BaseLocale.fetchByCodeDepartement(20), {message: 'Aucune Base Locale trouvée'})
+  const basesLocales = await BaseLocale.fetchByCommunes(['77123'])
+
+  t.is(basesLocales.length, 0)
 })

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -5,7 +5,6 @@ const {generateBase62String} = require('../util/base62')
 const {validPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {sendMail} = require('../util/sendmail')
-const {getCommunesByDepartement} = require('../util/cog')
 const createTokenRenewalNotificationEmail = require('../emails/token-renewal-notification')
 const createBalCreationNotificationEmail = require('../emails/bal-creation-notification')
 const createNewAdminNotificationEmail = require('../emails/new-admin-notification')
@@ -108,15 +107,8 @@ async function fetchAll() {
   return mongo.db.collection('bases_locales').find({}).toArray()
 }
 
-async function fetchByCodeDepartement(codeDepartement) {
-  const codesCommunes = getCommunesByDepartement(codeDepartement).map(c => c.code)
-  const basesLocales = await mongo.db.collection('bases_locales').find({communes: {$elemMatch: {$in: codesCommunes}}}).toArray()
-
-  if (basesLocales.length === 0) {
-    throw new Error('Aucune Base Locale trouvée')
-  }
-
-  return basesLocales
+async function fetchByCommunes(codesCommunes) {
+  return mongo.db.collection('bases_locales').find({communes: {$elemMatch: {$in: codesCommunes}}}).toArray()
 }
 
 async function remove(id) {
@@ -282,7 +274,7 @@ module.exports = {
   updateSchema,
   fetchOne,
   fetchAll,
-  fetchByCodeDepartement,
+  fetchByCommunes,
   remove,
   renewToken,
   addCommune,

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -507,6 +507,7 @@ test.serial('renew token / without admin token', async t => {
 test.serial('get Bases Locales with a code departement', async t => {
   const _idBalA = new mongo.ObjectID()
   const _idBalB = new mongo.ObjectID()
+  const _idBalC = new mongo.ObjectID()
 
   await mongo.db.collection('bases_locales').insertOne({
     _id: _idBalA,
@@ -532,8 +533,20 @@ test.serial('get Bases Locales with a code departement', async t => {
     _updated: new Date('2019-01-01')
   })
 
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBalC,
+    nom: 'fobaro',
+    description: 'bar',
+    emails: ['you@domain.tld'],
+    enableComplement: false,
+    communes: ['33345'],
+    token: 'hello',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
   const {body, status} = await request(getApp())
-    .get('/stats/departement/54')
+    .get('/stats/departements/54')
   t.is(status, 200)
   t.is(body.length, 2)
   t.true(SAFE_FIELDS.every(k => k in body[0]))
@@ -555,8 +568,10 @@ test.serial('get Bases Locales with code departement / invalid code departement'
     _updated: new Date('2019-01-01')
   })
 
-  const {status} = await request(getApp())
-    .get('/stats/departement/20')
-  t.is(status, 500)
+  const {status, body} = await request(getApp())
+    .get('/stats/departements/20')
+  t.is(status, 404)
+  t.is(body.code, 404)
+  t.is(body.message, 'Le département 20 n’existe pas.')
 })
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const bodyParser = require('body-parser')
+const departements = require('@etalab/decoupage-administratif/data/departements.json')
 const w = require('../util/w')
 const BaseLocale = require('../models/base-locale')
 const Voie = require('../models/voie')
@@ -189,7 +190,8 @@ app.route('/stats/departements/:codeDepartement')
   .get(w(async (req, res) => {
     const {codeDepartement} = req.params
     const codesCommunes = getCommunesByDepartement(codeDepartement).map(c => c.code)
-    if (codesCommunes.length === 0) {
+
+    if (!departements.some(d => d.code === codeDepartement)) {
       return res.status(404).send({code: 404, message: `Le département ${codeDepartement} n’existe pas.`})
     }
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -5,6 +5,7 @@ const BaseLocale = require('../models/base-locale')
 const Voie = require('../models/voie')
 const Numero = require('../models/numero')
 const {ValidationError} = require('../util/payload')
+const {getCommunesByDepartement} = require('../util/cog')
 
 const app = new express.Router()
 
@@ -184,10 +185,16 @@ app.route('/numeros/:numeroId')
     res.sendStatus(204)
   }))
 
-app.route('/stats/departement/:codeDepartement')
+app.route('/stats/departements/:codeDepartement')
   .get(w(async (req, res) => {
     const {codeDepartement} = req.params
-    const basesLocales = await BaseLocale.fetchByCodeDepartement(codeDepartement)
+    const codesCommunes = getCommunesByDepartement(codeDepartement).map(c => c.code)
+    if (codesCommunes.length === 0) {
+      return res.status(404).send({code: 404, message: `Le département ${codeDepartement} n’existe pas.`})
+    }
+
+    const basesLocales = await BaseLocale.fetchByCommunes(codesCommunes)
+
     res.send(basesLocales.map(bal => BaseLocale.filterSensitiveFields(bal)))
   }))
 


### PR DESCRIPTION
- En cas de recherche d'un département inexistant, renvoie :  
```json 
{"code": 404, "message": "Le département :codeDepartement n’existe pas"}
```
- Renvoi d'un tableau vide si aucune Base Locale n'est trouvée
- Ajout des tests liés aux changements des méthodes utilisées
- Modification de la route : 
  - Avant -> `/stats/departement/:codeDepartement`
  - Après ->  `/stats/departements/:codeDepartement`