### PR TITLE
Ajout d'une route pour créer et transformer une Base Adresse Locale de Test

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -47,6 +47,16 @@ test('create a BaseLocale / test', async t => {
   t.is(baseLocale.nom, 'Base locale [TEST]')
 })
 
+test('create BaseLocale test', async t => {
+  const baseLocale = await BaseLocale.createBaseLocaleTest()
+  const keys = ['isTest', 'nom', 'description', 'status', 'token', '_updated', '_created', '_id', 'communes']
+  t.true(keys.every(k => k in baseLocale))
+  t.is(Object.keys(baseLocale).length, 9)
+  t.is(baseLocale.nom, 'Base locale [TEST]')
+  t.is(baseLocale.status, 'draft') // TO DO : Replace by "test"
+  t.is(baseLocale.isTest, true) // TO DO : Should be removed and replace by "draft" status
+})
+
 test('update a BaseLocale', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('bases_locales').insertOne({
@@ -83,6 +93,73 @@ test('update a BaseLocale', async t => {
 test('update a BaseLocale / not found', t => {
   const _id = new mongo.ObjectID()
   return t.throwsAsync(() => BaseLocale.update(_id, {nom: 'foo'}), {message: 'BaseLocale not found'})
+})
+
+test('transform test to draft', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'Base locale [TEST]',
+    description: null,
+    communes: [],
+    token: 'coucou',
+    status: 'draft',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const baseLocale = await BaseLocale.transformTestToDraft(_id, {
+    nom: 'nom de ma BAL',
+    emails: ['monmail@mail.com']
+  })
+
+  t.is(baseLocale.nom, 'nom de ma BAL')
+  t.deepEqual(baseLocale.emails, ['monmail@mail.com'])
+  t.is(baseLocale.enableComplement, false)
+  t.is(baseLocale.token, 'coucou')
+  t.is(baseLocale.status, 'draft')
+  t.is(baseLocale.isTest, false)
+  t.is(Object.keys(baseLocale).length, 11)
+})
+
+test('transform test to draft / without nom', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'Base locale [TEST]',
+    description: null,
+    communes: [],
+    token: 'coucou',
+    status: 'draft',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const baseLocale = await BaseLocale.transformTestToDraft(_id, {
+    emails: ['monmail@mail.com']
+  })
+
+  t.is(baseLocale.nom, 'Base Locale')
+  t.deepEqual(baseLocale.emails, ['monmail@mail.com'])
+})
+
+test('transform test to draft / without emails', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'Base locale [TEST]',
+    description: null,
+    communes: [],
+    token: 'coucou',
+    status: 'draft',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  return t.throwsAsync(() => BaseLocale.transformTestToDraft(_id, {nom: 'Autre nom de BAL'}), {message: 'Invalid payload'})
+})
+
+test('transform test to draft / invalid _id', t => {
+  const _id = new mongo.ObjectID()
+  return t.throwsAsync(() => BaseLocale.transformTestToDraft(_id, {emails: ['monmail@Mail.com']}), {message: 'BaseLocale not found'})
 })
 
 test('remove a BaseLocale', async t => {

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -37,16 +37,6 @@ test('create a BaseLocale / minimal', async t => {
   t.is(Object.keys(baseLocale).length, 10)
 })
 
-test('create a BaseLocale / test', async t => {
-  const baseLocale = await BaseLocale.create({
-    isTest: true
-  })
-  const keys = ['isTest', 'nom', 'description', 'status', 'token', '_updated', '_created', '_id', 'communes']
-  t.true(keys.every(k => k in baseLocale))
-  t.is(Object.keys(baseLocale).length, 9)
-  t.is(baseLocale.nom, 'Base locale [TEST]')
-})
-
 test('create BaseLocale test', async t => {
   const baseLocale = await BaseLocale.createBaseLocaleTest()
   const keys = ['isTest', 'nom', 'description', 'status', 'token', '_updated', '_created', '_id', 'communes']

--- a/lib/models/__tests__/base-locale.schema.js
+++ b/lib/models/__tests__/base-locale.schema.js
@@ -1,5 +1,5 @@
 const test = require('ava')
-const {createSchema, createTestBalSchema, updateSchema} = require('../base-locale')
+const {createSchema, updateSchema} = require('../base-locale')
 
 test('valid payload', t => {
   const baseLocale = {
@@ -113,25 +113,4 @@ test('not valid payload: invalid status', t => {
   const {error} = updateSchema.validate(baseLocale)
 
   t.true(error.message.includes('"status" must be one of [draft, ready-to-publish]'))
-})
-
-test('valid test payload', t => {
-  const baseLocale = {
-    isTest: true
-  }
-
-  const {error} = createTestBalSchema.validate(baseLocale)
-
-  t.is(error, undefined)
-})
-
-test('invalid test payload', t => {
-  const baseLocale = {
-    isTest: true,
-    foo: 'bar'
-  }
-
-  const {error} = createTestBalSchema.validate(baseLocale)
-
-  t.true(error.message.includes('"foo" is not allowed'))
 })

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -17,19 +17,6 @@ const {transformToGeoJSON} = require('../export/geojson')
 const Voie = require('./voie')
 const Numero = require('./numero')
 
-function getNomBaseLocale(baseLocale) {
-  const {isTest} = baseLocale
-  if (isTest) {
-    return 'Base locale [TEST]'
-  }
-
-  return baseLocale.nom || null
-}
-
-const createTestBalSchema = Joi.object().keys({
-  isTest: Joi.boolean().invalid(false)
-})
-
 const createSchema = Joi.object().keys({
   nom: Joi.string().max(200).allow(null),
   description: Joi.string().max(2000).allow(null),
@@ -40,12 +27,11 @@ const createSchema = Joi.object().keys({
 })
 
 async function create(payload) {
-  const schema = payload.isTest ? createTestBalSchema : createSchema
-  const baseLocale = validPayload(payload, schema)
+  const baseLocale = validPayload(payload, createSchema)
 
   baseLocale.token = generateBase62String(20)
   baseLocale.communes = []
-  baseLocale.nom = getNomBaseLocale(baseLocale)
+  baseLocale.nom = baseLocale.nom || null
   baseLocale.description = baseLocale.description || null
   baseLocale.status = 'draft'
 
@@ -366,7 +352,6 @@ async function computeStats() {
 module.exports = {
   create,
   createSchema,
-  createTestBalSchema,
   createBaseLocaleTest,
   transformTestToDraft,
   update,

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -62,6 +62,24 @@ async function create(payload) {
   return baseLocale
 }
 
+async function createBaseLocaleTest() {
+  const baseLocale = {}
+
+  baseLocale.token = generateBase62String(20)
+  baseLocale.communes = []
+  baseLocale.nom = 'Base locale [TEST]'
+  baseLocale.description = null
+  baseLocale.status = 'draft' // TO DO : Replace by "test"
+  baseLocale.isTest = true // TO DO : Should be removed and replace by "draft" status
+
+  mongo.decorateCreation(baseLocale)
+
+  const {insertedId} = await mongo.db.collection('bases_locales').insertOne(baseLocale)
+  baseLocale._id = insertedId
+
+  return baseLocale
+}
+
 const updateSchema = Joi.object().keys({
   nom: Joi.string().max(200).allow(null),
   description: Joi.string().max(2000).allow(null),
@@ -97,6 +115,36 @@ async function update(id, payload) {
     const notification = createNewAdminNotificationEmail({baseLocale: value})
     await Promise.all(newCollaborators.map(collaborator => sendMail(notification, [collaborator])))
   }
+
+  return value
+}
+
+async function transformTestToDraft(id, payload) {
+  const currentBaseLocale = await mongo.db.collection('bases_locales').findOne({_id: mongo.parseObjectID(id)})
+
+  if (!currentBaseLocale) {
+    throw new Error('BaseLocale not found')
+  }
+
+  const changes = validPayload(payload, createSchema)
+
+  const baseLocale = {
+    ...currentBaseLocale,
+    ...changes,
+    nom: changes.nom || 'Base Locale',
+    isTest: false
+  }
+
+  mongo.decorateModification(baseLocale)
+
+  const {value} = await mongo.db.collection('bases_locales').findOneAndUpdate(
+    {_id: mongo.parseObjectID(id)},
+    {$set: baseLocale},
+    {returnOriginal: false}
+  )
+
+  const email = createBalCreationNotificationEmail({baseLocale})
+  await sendMail(email, baseLocale.emails)
 
   return value
 }
@@ -319,6 +367,8 @@ module.exports = {
   create,
   createSchema,
   createTestBalSchema,
+  createBaseLocaleTest,
+  transformTestToDraft,
   update,
   updateSchema,
   fetchOne,

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -79,9 +79,11 @@ app.route('/bases-locales/test')
     const baseLocale = await BaseLocale.createBaseLocaleTest()
     res.status(201).send(baseLocale)
   }))
-  .put(w(async (req, res) => {
-    const baseLocale = await BaseLocale.transformTestToDraft(req.body)
-    res.status(201).send(baseLocale)
+
+app.route('/bases-locales/test/:baseLocaleId')
+  .put(ensureIsAdmin, w(async (req, res) => {
+    const baseLocale = await BaseLocale.transformTestToDraft(req.baseLocale._id, req.body)
+    res.send(baseLocale)
   }))
 
 app.route('/bases-locales/:baseLocaleId')

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -74,6 +74,16 @@ app.route('/bases-locales')
     res.status(201).send(baseLocale)
   }))
 
+app.route('/bases-locales/test')
+  .post(w(async (req, res) => {
+    const baseLocale = await BaseLocale.createBaseLocaleTest()
+    res.status(201).send(baseLocale)
+  }))
+  .put(w(async (req, res) => {
+    const baseLocale = await BaseLocale.transformTestToDraft(req.body)
+    res.status(201).send(baseLocale)
+  }))
+
 app.route('/bases-locales/:baseLocaleId')
   .get(w(async (req, res) => {
     if (req.isAdmin) {


### PR DESCRIPTION
- ` POST /bases-locales/test` Création de la route pour créer une Base Adresse Locale de test avec champs prédéfinis
- `PUT /bases-locales/test` Transformation de la Base Adresse Locale de test à condition de fournir une adresse mail et un nom (optionnel)