### PR TITLE
Ajout du modèle Commune

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -251,6 +251,25 @@ test('add a commune', async t => {
   t.deepEqual(communes.map(({code}) => code), ['12345', '54084'])
 })
 
+test('add a commune / already exist', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345']
+  })
+
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345'
+  })
+
+  await t.throwsAsync(() => BaseLocale.addCommune(_id, '12345'), {message: 'Cette commune existe déjà dans cette base locale'})
+  t.is(await mongo.db.collection('communes').countDocuments({_bal: _id, code: '12345'}), 1)
+})
+
 test('add a commune / invalid code commune', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('bases_locales').insertOne({

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -21,17 +21,16 @@ test('create a BaseLocale', async t => {
     emails: ['me@domain.co'],
     enableComplement: false
   })
-  const keys = ['nom', 'status', 'emails', 'token', '_updated', '_created', '_id', 'communes', 'enableComplement']
+  const keys = ['nom', 'emails', 'token', '_updated', '_created', '_id', 'communes', 'enableComplement']
   t.true(keys.every(k => k in baseLocale))
-  t.true(baseLocale.status === 'draft')
-  t.is(Object.keys(baseLocale).length, 9)
+  t.is(Object.keys(baseLocale).length, 8)
 })
 
 test('create a BaseLocale / minimal', async t => {
   const baseLocale = await BaseLocale.create({emails: ['me@domain.co']})
-  const keys = ['nom', 'status', 'emails', 'token', '_updated', '_created', '_id', 'communes', 'enableComplement']
+  const keys = ['nom', 'emails', 'token', '_updated', '_created', '_id', 'communes', 'enableComplement']
   t.true(keys.every(k => k in baseLocale))
-  t.is(Object.keys(baseLocale).length, 9)
+  t.is(Object.keys(baseLocale).length, 8)
 })
 
 test('create a BaseLocale / demo', async t => {
@@ -39,12 +38,15 @@ test('create a BaseLocale / demo', async t => {
     commune: '27115',
     populate: false
   })
-  const keys = ['nom', 'status', 'token', '_updated', '_created', '_id', 'communes']
+  const keys = ['nom', 'isDemo', 'token', '_updated', '_created', '_id', 'communes']
   t.true(keys.every(k => k in baseLocale))
   t.is(Object.keys(baseLocale).length, 7)
   t.is(baseLocale.nom, 'Adresses de Breux-sur-Avre [démo]')
+  t.is(baseLocale.isDemo, true)
   t.deepEqual(baseLocale.communes, ['27115'])
-  t.is(baseLocale.status, 'demo')
+
+  const commune = await mongo.db.collection('communes').findOne({_bal: mongo.parseObjectID(baseLocale._id)})
+  t.is(commune.status, 'demo')
 })
 
 test('create a demo BaseLocale / invalid commune', async t => {
@@ -84,7 +86,6 @@ test('update a BaseLocale', async t => {
     enableComplement: false,
     communes: [],
     token: 'coucou',
-    status: 'draft',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -93,7 +94,6 @@ test('update a BaseLocale', async t => {
     nom: 'foo2',
     emails: ['me2@domain.co', 'me3@domain.co'],
     enableComplement: false,
-    status: 'ready-to-publish',
     token: 'hack'
   })
 
@@ -101,8 +101,7 @@ test('update a BaseLocale', async t => {
   t.deepEqual(baseLocale.emails, ['me2@domain.co', 'me3@domain.co'])
   t.is(baseLocale.enableComplement, false)
   t.is(baseLocale.token, 'coucou')
-  t.is(baseLocale.status, 'ready-to-publish')
-  t.is(Object.keys(baseLocale).length, 9)
+  t.is(Object.keys(baseLocale).length, 8)
 })
 
 test('update a BaseLocale / not found', t => {
@@ -116,7 +115,16 @@ test('transform to draft', async t => {
     _id,
     nom: 'Base Adresse Locale [DEMO]',
     communes: ['27115'],
+    isDemo: true,
     token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommune,
+    _bal: _id,
+    code: '27115',
     status: 'demo',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -128,10 +136,15 @@ test('transform to draft', async t => {
     email: 'me2@domain.co'
   })
 
-  t.is(baseLocale.nom, 'foo2')
-  t.deepEqual(baseLocale.emails, ['me2@domain.co'])
-  t.is(baseLocale.status, 'draft')
+  const keys = ['nom', 'isDemo', 'emails', 'token', '_updated', '_created', '_id', 'communes']
+  t.true(keys.every(k => k in baseLocale))
   t.is(Object.keys(baseLocale).length, 8)
+  t.is(baseLocale.nom, 'foo2')
+  t.is(baseLocale.isDemo, false)
+  t.deepEqual(baseLocale.emails, ['me2@domain.co'])
+
+  const commune = await mongo.db.collection('communes').findOne({_id: _idCommune})
+  t.is(commune.status, 'draft')
 })
 
 test('transform to draft / default nom', async t => {
@@ -141,6 +154,15 @@ test('transform to draft / default nom', async t => {
     nom: 'Base Adresse Locale [DEMO]',
     communes: ['27115'],
     token: 'coucou',
+    isDemo: true,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '27115',
     status: 'demo',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -151,21 +173,28 @@ test('transform to draft / default nom', async t => {
     email: 'me2@domain.co'
   })
 
+  const keys = ['nom', 'isDemo', 'emails', 'token', '_updated', '_created', '_id', 'communes']
+  t.true(keys.every(k => k in baseLocale))
   t.is(baseLocale.nom, 'Adresses de Breux-sur-Avre')
+  t.is(baseLocale.isDemo, false)
   t.deepEqual(baseLocale.emails, ['me2@domain.co'])
-  t.is(baseLocale.status, 'draft')
   t.is(Object.keys(baseLocale).length, 8)
+
+  const commune = await mongo.db.collection('communes').findOne({_id: _idCommune})
+  t.is(commune.status, 'draft')
 })
 
 test('remove a BaseLocale', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('bases_locales').insertOne({_id, nom: 'foo'})
+  await mongo.db.collection('communes').insertOne({_bal: _id, code: '27115'})
   await mongo.db.collection('voies').insertOne({_bal: _id, nom: 'foo'})
   await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1})
 
   await BaseLocale.remove(_id)
 
   t.falsy(await mongo.db.collection('bases_locales').findOne({_id}))
+  t.falsy(await mongo.db.collection('communes').findOne({_bal: _id}))
   t.falsy(await mongo.db.collection('voies').findOne({_bal: _id}))
   t.falsy(await mongo.db.collection('numeros').findOne({_bal: _id}))
 })
@@ -173,12 +202,14 @@ test('remove a BaseLocale', async t => {
 test('cleanContent', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('bases_locales').insertOne({_id, nom: 'foo'})
+  await mongo.db.collection('communes').insertOne({_bal: _id, code: '27115'})
   await mongo.db.collection('voies').insertOne({_bal: _id, nom: 'foo'})
   await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1})
 
   await BaseLocale.cleanContent(_id)
 
   t.truthy(await mongo.db.collection('bases_locales').findOne({_id}))
+  t.falsy(await mongo.db.collection('communes').findOne({_bal: _id}))
   t.falsy(await mongo.db.collection('voies').findOne({_bal: _id}))
   t.falsy(await mongo.db.collection('numeros').findOne({_bal: _id}))
 })
@@ -205,9 +236,19 @@ test('add a commune', async t => {
     communes: ['12345']
   })
 
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345'
+  })
+
   const baseLocale = await BaseLocale.addCommune(_id, '54084')
 
   t.deepEqual(baseLocale.communes, ['12345', '54084'])
+  const communes = await mongo.db.collection('communes').find({_bal: mongo.parseObjectID(_id)}).toArray()
+  t.is(communes.length, 2)
+  t.deepEqual(communes.map(({code}) => code), ['12345', '54084'])
 })
 
 test('add a commune / invalid code commune', async t => {
@@ -228,12 +269,14 @@ test('clean a commune', async t => {
     token: 'coucou',
     communes: ['54084']
   })
+  await mongo.db.collection('communes').insertOne({_bal: _id, code: '54084'})
   await mongo.db.collection('voies').insertOne({_bal: _id, nom: 'foo', commune: '54084'})
   await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1, commune: '54084'})
 
   const baseLocale = await BaseLocale.cleanCommune(_id, '54084')
 
   t.deepEqual(baseLocale.communes, ['54084'])
+  t.falsy(await mongo.db.collection('communes').findOne({_bal: _id, code: '54084'}))
   t.falsy(await mongo.db.collection('voies').findOne({_bal: _id, commune: '54084'}))
   t.falsy(await mongo.db.collection('numeros').findOne({_bal: _id, commune: '54084'}))
 })
@@ -245,12 +288,14 @@ test('remove a commune', async t => {
     token: 'coucou',
     communes: ['54084']
   })
+  await mongo.db.collection('communes').insertOne({_bal: _id, code: '54084'})
   await mongo.db.collection('voies').insertOne({_bal: _id, nom: 'foo', commune: '54084'})
   await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1, commune: '54084'})
 
   const baseLocale = await BaseLocale.removeCommune(_id, '54084')
 
   t.deepEqual(baseLocale.communes, [])
+  t.falsy(await mongo.db.collection('communes').findOne({_bal: _id, code: '54084'}))
   t.falsy(await mongo.db.collection('voies').findOne({_bal: _id, commune: '54084'}))
   t.falsy(await mongo.db.collection('numeros').findOne({_bal: _id, commune: '54084'}))
 })
@@ -262,6 +307,7 @@ test('populate a commune', async t => {
     token: 'coucou',
     communes: ['54084']
   })
+  await mongo.db.collection('communes').insertOne({_bal: _id, code: '54084'})
   await mongo.db.collection('voies').insertOne({_bal: _id, nom: 'foo', commune: '54084'})
   await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1, commune: '54084'})
 
@@ -269,6 +315,7 @@ test('populate a commune', async t => {
   const baseLocale = await BaseLocale.populateCommune(_id, '54084')
 
   t.deepEqual(baseLocale.communes, ['54084'])
+  t.is(await mongo.db.collection('communes').countDocuments({_bal: _id, code: '54084'}), 1)
 
   const voie = await mongo.db.collection('voies').findOne({_bal: _id, commune: '54084', nom: 'allée des acacias'})
   t.truthy(voie)

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -311,6 +311,154 @@ test('add a commune / invalid code commune', async t => {
   await t.throwsAsync(() => BaseLocale.addCommune(_id, '00000'))
 })
 
+test('Update commune status / base locale is demo', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345'],
+    isDemo: true
+  })
+
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345',
+    status: 'demo'
+  })
+
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+
+  await t.throwsAsync(BaseLocale.updateCommuneStatus(baseLocale, '12345', 'draft'), {message: 'Impossible de modifier le statut d’une commune d’une Base Locale de démonstration'})
+})
+
+test('Update commune status / draft to ready-to-publish', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345']
+  })
+
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345',
+    status: 'draft'
+  })
+
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+  const commune = await BaseLocale.updateCommuneStatus(baseLocale, '12345', 'ready-to-publish')
+
+  t.is(commune.status, 'ready-to-publish')
+})
+
+test('Update commune status / draft to published', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345']
+  })
+
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345',
+    status: 'draft'
+  })
+
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+  await t.throwsAsync(BaseLocale.updateCommuneStatus(baseLocale, '12345', 'published'), {message: 'Seule une commune prête à être publiée peut être publiée'})
+})
+
+test('Update commune status / draft to demo', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345']
+  })
+
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345',
+    status: 'draft'
+  })
+
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+  await t.throwsAsync(BaseLocale.updateCommuneStatus(baseLocale, '12345', 'demo'))
+})
+
+test('Update commune status / ready-to-publish to draft', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345']
+  })
+
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345',
+    status: 'ready-to-publish'
+  })
+
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+  const commune = await BaseLocale.updateCommuneStatus(baseLocale, '12345', 'draft')
+
+  t.is(commune.status, 'draft')
+})
+
+test('Update commune status / ready-to-publish to published', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345']
+  })
+
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345',
+    status: 'ready-to-publish'
+  })
+
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+  const commune = await BaseLocale.updateCommuneStatus(baseLocale, '12345', 'published')
+
+  t.is(commune.status, 'published')
+})
+
+test('Update commune status / published to ready-to-publish', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345']
+  })
+
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345',
+    status: 'published'
+  })
+
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id})
+  await t.throwsAsync(BaseLocale.updateCommuneStatus(baseLocale, '12345', 'ready-to-publish'), {message: 'Impossible de changer le status d’une Base Locale publiée'})
+})
+
 test('clean a commune', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('bases_locales').insertOne({

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -228,6 +228,36 @@ test('renew token', async t => {
   t.is(baseLocale.token.length, 20)
 })
 
+test('get commune', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345']
+  })
+
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    _id: _idCommune,
+    code: '12345'
+  })
+
+  const commune = await BaseLocale.getCommune(_id, '12345')
+  t.is(commune.code, '12345')
+})
+
+test('get commune / no commune', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['12345']
+  })
+
+  await t.throwsAsync(() => BaseLocale.getCommune(_id, '12345'), {message: 'Commune non trouvée'})
+})
+
 test('add a commune', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('bases_locales').insertOne({

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -43,7 +43,7 @@ test('create a BaseLocale / demo', async t => {
   t.is(Object.keys(baseLocale).length, 7)
   t.is(baseLocale.nom, 'Adresses de Breux-sur-Avre [démo]')
   t.is(baseLocale.isDemo, true)
-  t.deepEqual(baseLocale.communes, ['27115'])
+  t.deepEqual(baseLocale.communes, [{code: '27115', status: 'demo'}])
 
   const commune = await mongo.db.collection('communes').findOne({_bal: mongo.parseObjectID(baseLocale._id)})
   t.is(commune.status, 'demo')
@@ -278,7 +278,7 @@ test('add a commune', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345']
+    communes: [{code: '12345'}]
   })
 
   const _idCommune = new mongo.ObjectID()
@@ -290,7 +290,7 @@ test('add a commune', async t => {
 
   const baseLocale = await BaseLocale.addCommune(_id, '54084')
 
-  t.deepEqual(baseLocale.communes, ['12345', '54084'])
+  t.deepEqual(baseLocale.communes, [{code: '12345'}, {code: '54084', status: 'draft'}])
   const communes = await mongo.db.collection('communes').find({_bal: mongo.parseObjectID(_id)}).toArray()
   t.is(communes.length, 2)
   t.deepEqual(communes.map(({code}) => code), ['12345', '54084'])
@@ -301,7 +301,7 @@ test('add a commune / already exist', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345']
+    communes: [{code: '12345'}]
   })
 
   const _idCommune = new mongo.ObjectID()
@@ -320,7 +320,7 @@ test('add a commune / invalid code commune', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345']
+    communes: [{code: '12345'}]
   })
 
   await t.throwsAsync(() => BaseLocale.addCommune(_id, '00000'))
@@ -331,7 +331,7 @@ test('Update commune status / base locale is demo', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345'],
+    communes: [{code: '12345'}],
     isDemo: true
   })
 
@@ -353,7 +353,7 @@ test('Update commune status / draft to ready-to-publish', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345']
+    communes: [{code: '12345'}]
   })
 
   const _idCommune = new mongo.ObjectID()
@@ -375,7 +375,7 @@ test('Update commune status / draft to published', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345']
+    communes: [{code: '12345'}]
   })
 
   const _idCommune = new mongo.ObjectID()
@@ -395,7 +395,7 @@ test('Update commune status / draft to demo', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345']
+    communes: [{code: '12345'}]
   })
 
   const _idCommune = new mongo.ObjectID()
@@ -415,7 +415,7 @@ test('Update commune status / ready-to-publish to draft', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345']
+    communes: [{code: '12345'}]
   })
 
   const _idCommune = new mongo.ObjectID()
@@ -437,7 +437,7 @@ test('Update commune status / ready-to-publish to published', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345']
+    communes: [{code: '12345'}]
   })
 
   const _idCommune = new mongo.ObjectID()
@@ -459,7 +459,7 @@ test('Update commune status / published to ready-to-publish', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['12345']
+    communes: [{code: '12345'}]
   })
 
   const _idCommune = new mongo.ObjectID()
@@ -479,7 +479,7 @@ test('clean a commune', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['54084']
+    communes: [{code: '54084'}]
   })
   await mongo.db.collection('communes').insertOne({_bal: _id, code: '54084'})
   await mongo.db.collection('voies').insertOne({_bal: _id, nom: 'foo', commune: '54084'})
@@ -487,7 +487,7 @@ test('clean a commune', async t => {
 
   const baseLocale = await BaseLocale.cleanCommune(_id, '54084')
 
-  t.deepEqual(baseLocale.communes, ['54084'])
+  t.deepEqual(baseLocale.communes, [{code: '54084'}])
   t.falsy(await mongo.db.collection('communes').findOne({_bal: _id, code: '54084'}))
   t.falsy(await mongo.db.collection('voies').findOne({_bal: _id, commune: '54084'}))
   t.falsy(await mongo.db.collection('numeros').findOne({_bal: _id, commune: '54084'}))
@@ -498,7 +498,7 @@ test('remove a commune', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['54084']
+    communes: [{code: '54084'}]
   })
   await mongo.db.collection('communes').insertOne({_bal: _id, code: '54084'})
   await mongo.db.collection('voies').insertOne({_bal: _id, nom: 'foo', commune: '54084'})
@@ -517,7 +517,7 @@ test('remove a commune / ready-to-publish', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['54084']
+    communes: [{code: '54084'}]
   })
   await mongo.db.collection('communes').insertOne({
     _bal: _id,
@@ -534,7 +534,8 @@ test('populate a commune', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['54084']
+    communes: [{code: '54084'}]
+
   })
   await mongo.db.collection('communes').insertOne({_bal: _id, code: '54084'})
   await mongo.db.collection('voies').insertOne({_bal: _id, nom: 'foo', commune: '54084'})
@@ -543,7 +544,7 @@ test('populate a commune', async t => {
   mockBan54()
   const baseLocale = await BaseLocale.populateCommune(_id, '54084')
 
-  t.deepEqual(baseLocale.communes, ['54084'])
+  t.deepEqual(baseLocale.communes, [{code: '54084'}])
   t.is(await mongo.db.collection('communes').countDocuments({_bal: _id, code: '54084'}), 1)
 
   const voie = await mongo.db.collection('voies').findOne({_bal: _id, commune: '54084', nom: 'allée des acacias'})
@@ -562,19 +563,19 @@ test('find Bases Locales by codes communes', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id: _idBalA,
     token: 'coucou1',
-    communes: ['47192']
+    communes: [{code: '47192'}]
   })
 
   await mongo.db.collection('bases_locales').insertOne({
     _id: _idBalB,
     token: 'coucou2',
-    communes: ['47178']
+    communes: [{code: '47178'}]
   })
 
   await mongo.db.collection('bases_locales').insertOne({
     _id: _idBalC,
     token: 'coucou',
-    communes: ['48678']
+    communes: [{code: '48678'}]
   })
 
   const basesLocales = await BaseLocale.fetchByCommunes(['47192', '47178', '47098'])
@@ -587,7 +588,7 @@ test('find Bases Locales by codes communes / no BAL found', async t => {
   await mongo.db.collection('bases_locales').insertOne({
     _id,
     token: 'coucou',
-    communes: ['54084']
+    communes: [{code: '54084'}]
   })
 
   const basesLocales = await BaseLocale.fetchByCommunes(['77123'])

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -199,6 +199,21 @@ test('remove a BaseLocale', async t => {
   t.falsy(await mongo.db.collection('numeros').findOne({_bal: _id}))
 })
 
+test('remove a BaseLocale / with commune ready-to-publish', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({_id, nom: 'foo'})
+  await mongo.db.collection('communes').insertOne({_bal: _id, code: '27115', status: 'ready-to-publish'})
+  await mongo.db.collection('voies').insertOne({_bal: _id, nom: 'foo'})
+  await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1})
+
+  await t.throwsAsync(BaseLocale.remove(_id), {message: 'Impossible de supprimer une Base Locale possèdant ou des communes publiées ou prêtes à être publiées'})
+
+  t.truthy(await mongo.db.collection('bases_locales').findOne({_id}))
+  t.truthy(await mongo.db.collection('communes').findOne({_bal: _id}))
+  t.truthy(await mongo.db.collection('voies').findOne({_bal: _id}))
+  t.truthy(await mongo.db.collection('numeros').findOne({_bal: _id}))
+})
+
 test('cleanContent', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('bases_locales').insertOne({_id, nom: 'foo'})
@@ -495,6 +510,23 @@ test('remove a commune', async t => {
   t.falsy(await mongo.db.collection('communes').findOne({_bal: _id, code: '54084'}))
   t.falsy(await mongo.db.collection('voies').findOne({_bal: _id, commune: '54084'}))
   t.falsy(await mongo.db.collection('numeros').findOne({_bal: _id, commune: '54084'}))
+})
+
+test('remove a commune / ready-to-publish', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['54084']
+  })
+  await mongo.db.collection('communes').insertOne({
+    _bal: _id,
+    code: '54084',
+    status: 'ready-to-publish'
+  })
+
+  await t.throwsAsync(BaseLocale.removeCommune(_id, '54084'), {message: 'Impossible de supprimer une commune prête à être publiée'})
+  t.truthy(await mongo.db.collection('communes').findOne({_bal: _id, code: '54084'}))
 })
 
 test('populate a commune', async t => {

--- a/lib/models/__tests__/base-locale.schema.js
+++ b/lib/models/__tests__/base-locale.schema.js
@@ -87,16 +87,6 @@ test('not valid payload: not allowed extra param', t => {
   t.is(error.message, '"extra" is not allowed')
 })
 
-test('not valid payload: invalid status', t => {
-  const baseLocale = {
-    status: 'invalid-status'
-  }
-
-  const {error} = updateSchema.validate(baseLocale)
-
-  t.true(error.message.includes('"status" must be one of [draft, ready-to-publish]'))
-})
-
 test('valid demo payload / create', t => {
   const baseLocale = {
     commune: '27115',

--- a/lib/models/__tests__/commune.mongo.js
+++ b/lib/models/__tests__/commune.mongo.js
@@ -1,0 +1,131 @@
+const test = require('ava')
+const {pick} = require('lodash')
+const {MongoMemoryServer} = require('mongodb-memory-server')
+const mongo = require('../../util/mongo')
+const Commune = require('../commune')
+
+const mongod = new MongoMemoryServer()
+
+test.before('start server', async () => {
+  await mongo.connect(await mongod.getUri())
+})
+
+test.after.always('cleanup', async () => {
+  await mongo.disconnect()
+  await mongod.stop()
+})
+
+test('create a Commune', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    _updated: new Date('2021-01-01')
+  })
+  const commune = await Commune.create(_id, {
+    code: '27115'
+  })
+
+  const keys = ['status', '_updated', '_created', '_id', '_bal', 'code']
+  t.true(keys.every(k => k in commune))
+  t.true(commune.status === 'draft')
+  t.is(Object.keys(commune).length, 6)
+})
+
+test('create a Commune : baseLocale not found', t => {
+  const _id = new mongo.ObjectID()
+  return t.throwsAsync(() => Commune.create(_id, {code: '27115'}))
+})
+
+test('create a Commune : demo', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    _updated: new Date('2021-01-01')
+  })
+  const commune = await Commune.create(_id, {
+    code: '27115',
+    status: 'demo'
+  })
+
+  t.true(commune.status === 'demo')
+})
+
+test('update a Commune', async t => {
+  const balId = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: balId,
+    _updated: new Date('2021-01-01')
+  })
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _id,
+    _bal: balId,
+    code: '27115',
+    status: 'draft',
+    _updated: new Date('2021-01-01')
+  })
+
+  const commune = await Commune.update(_id, {status: 'ready-to-publish'})
+
+  t.is(commune.code, '27115')
+  t.is(commune.status, 'ready-to-publish')
+})
+
+test('update a Commune / not found', t => {
+  const _id = new mongo.ObjectID()
+  return t.throwsAsync(() => Commune.update(_id, {code: '27115'}), {message: 'Commune not found'})
+})
+
+test('importMany', async t => {
+  const _idBal = new mongo.ObjectID()
+  const commune1 = {
+    _bal: _idBal,
+    code: '27115',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-05')
+  }
+  const commune2 = {
+    _bal: _idBal,
+    code: '54084'
+  }
+
+  Commune.importMany(_idBal, [commune1, commune2], {validate: false})
+  const communes = await mongo.db.collection('communes').find({_bal: _idBal}).toArray()
+  t.is(communes.length, 2)
+  const v1 = communes.find(v => v.code === '27115')
+  t.deepEqual(
+    pick(v1, 'code', '_updated', '_created'),
+    pick(commune1, 'code', 'status', '_updated', '_created')
+  )
+  const v2 = communes.find(v => v.code === '54084')
+  t.deepEqual(
+    pick(v2, 'code'),
+    pick(commune2, 'code', 'status')
+  )
+})
+
+test('importMany / keeping ids', async t => {
+  const _idBal = new mongo.ObjectID()
+  const _idCommune1 = new mongo.ObjectID()
+  const _idCommune2 = new mongo.ObjectID()
+  const commune1 = {
+    _id: _idCommune1,
+    _bal: _idBal,
+    code: '27115'
+  }
+  const commune2 = {
+    _id: _idCommune2,
+    _bal: _idBal,
+    code: '54084'
+  }
+
+  Commune.importMany(_idBal, [commune1, commune2], {validate: false, keepIds: true})
+  const communes = await mongo.db.collection('communes').find({_bal: _idBal}).toArray()
+  t.is(communes.length, 2)
+  const v1 = communes.find(v => v.code === '27115')
+  t.deepEqual(pick(v1, 'code'), pick(commune1, 'code'))
+  t.true(v1._id.equals(_idCommune1))
+  const v2 = communes.find(v => v.code === '54084')
+  t.deepEqual(pick(v2, 'code'), pick(commune2, 'code'))
+  t.true(v2._id.equals(_idCommune2))
+})

--- a/lib/models/__tests__/commune.schema.js
+++ b/lib/models/__tests__/commune.schema.js
@@ -70,5 +70,5 @@ test('invalid payload: change status to published', t => {
 
   const {error} = updateSchema.validate(commune)
 
-  t.is(error.message, '"status" must be one of [draft, ready-to-publish]')
+  t.is(error, undefined)
 })

--- a/lib/models/__tests__/commune.schema.js
+++ b/lib/models/__tests__/commune.schema.js
@@ -1,0 +1,74 @@
+const test = require('ava')
+const {createSchema, updateSchema} = require('../commune')
+
+test('valid payload', t => {
+  const commune = {
+    code: '27115'
+  }
+
+  const {error} = createSchema.validate(commune)
+
+  t.is(error, undefined)
+})
+
+test('valid payload: demo', t => {
+  const commune = {
+    code: '27115',
+    status: 'demo'
+  }
+
+  const {error} = createSchema.validate(commune)
+
+  t.is(error, undefined)
+})
+
+test('invalid payload: invalid code commune', t => {
+  const commune = {
+    code: 'xxxxx'
+  }
+
+  const {error} = createSchema.validate(commune)
+
+  t.is(error.message, '"code" contains an invalid value')
+})
+
+test('invalid payload: invalid status', t => {
+  const commune = {
+    code: '27115',
+    status: 'invalid'
+  }
+
+  const {error} = createSchema.validate(commune)
+
+  t.is(error.message, '"status" must be one of [demo, draft]')
+})
+
+test('valid payload: change status to draft', t => {
+  const commune = {
+    status: 'draft'
+  }
+
+  const {error} = updateSchema.validate(commune)
+
+  t.is(error, undefined)
+})
+
+test('valid payload: change status to ready-to-publish', t => {
+  const commune = {
+    status: 'ready-to-publish'
+  }
+
+  const {error} = updateSchema.validate(commune)
+
+  t.is(error, undefined)
+})
+
+test('invalid payload: change status to published', t => {
+  const commune = {
+    status: 'published'
+  }
+
+  const {error} = updateSchema.validate(commune)
+
+  t.is(error.message, '"status" must be one of [draft, ready-to-publish]')
+})

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -201,6 +201,16 @@ async function renewToken(id) {
   return value
 }
 
+async function getCommune(idBal, codeCommune) {
+  const commune = await mongo.db.collection('communes').findOne({_bal: idBal, code: codeCommune})
+
+  if (!commune) {
+    throw new Error('Commune non trouvée')
+  }
+
+  return commune
+}
+
 async function addCommune(id, codeCommune) {
   const baseLocale = await mongo.db.collection('bases_locales').findOne({_id: id})
 
@@ -405,6 +415,7 @@ module.exports = {
   fetchByCommunes,
   remove,
   renewToken,
+  getCommune,
   addCommune,
   cleanCommune,
   removeCommune,

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -357,6 +357,12 @@ async function exportAsCsv(id) {
   return adressesToCsv({voies, numeros})
 }
 
+async function exportCommuneAsCsv(id, codeCommune) {
+  const voies = await mongo.db.collection('voies').find({_bal: mongo.parseObjectID(id), commune: codeCommune}).toArray()
+  const numeros = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(id), commune: codeCommune}).toArray()
+  return adressesToCsv({voies, numeros})
+}
+
 async function streamToGeoJSON(id, codeCommune) {
   const voiesCursor = mongo.db.collection('voies').find({_bal: id, commune: codeCommune})
   const numerosCursor = mongo.db.collection('numeros').find({_bal: id, commune: codeCommune, 'positions.point': {$exists: true}})
@@ -474,6 +480,7 @@ module.exports = {
   removeCommune,
   populateCommune,
   exportAsCsv,
+  exportCommuneAsCsv,
   streamToGeoJSON,
   cleanContent,
   importFile,

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -18,6 +18,10 @@ const Commune = require('./commune')
 const Voie = require('./voie')
 const Numero = require('./numero')
 
+function hasCommune(communes, codeCommune) {
+  return communes.map(({code}) => code).includes(codeCommune)
+}
+
 const createSchema = Joi.object().keys({
   nom: Joi.string().max(200).allow(null),
   emails: Joi.array().min(1).items(
@@ -64,12 +68,13 @@ const createDemoSchema = Joi.object().keys({
 })
 
 async function createDemo(payload) {
-  const {commune, populate} = validPayload(payload, createDemoSchema)
+  const {commune: codeCommune, populate} = validPayload(payload, createDemoSchema)
+  const commune = {code: codeCommune, status: 'demo'}
 
   const baseLocale = {
     token: generateBase62String(20),
     communes: [commune],
-    nom: `Adresses de ${getNomCommune(commune)} [démo]`,
+    nom: `Adresses de ${getNomCommune(codeCommune)} [démo]`,
     isDemo: true
   }
 
@@ -78,10 +83,10 @@ async function createDemo(payload) {
   const {insertedId} = await mongo.db.collection('bases_locales').insertOne(baseLocale)
   baseLocale._id = insertedId
 
-  await Commune.create(baseLocale._id, {code: commune, status: 'demo'})
+  await Commune.create(baseLocale._id, commune)
 
   if (populate) {
-    await populateCommune(baseLocale._id, commune)
+    await populateCommune(baseLocale._id, codeCommune)
   }
 
   return baseLocale
@@ -175,7 +180,7 @@ async function fetchAll() {
 }
 
 async function fetchByCommunes(codesCommunes) {
-  return mongo.db.collection('bases_locales').find({communes: {$elemMatch: {$in: codesCommunes}}}).toArray()
+  return mongo.db.collection('bases_locales').find({communes: {$elemMatch: {code: {$in: codesCommunes}}}}).toArray()
 }
 
 async function remove(id) {
@@ -226,17 +231,20 @@ async function addCommune(id, codeCommune) {
     throw new Error('Base locale non trouvée')
   }
 
-  if (baseLocale.communes.includes(codeCommune)) {
+  if (hasCommune(baseLocale.communes, codeCommune)) {
     throw new Error('Cette commune existe déjà dans cette base locale')
   }
 
-  const status = baseLocale.isDemo ? 'demo' : 'draft'
+  const commune = {
+    code: codeCommune,
+    status: baseLocale.isDemo ? 'demo' : 'draft'
+  }
 
-  await Commune.create(id, {code: codeCommune, status})
+  await Commune.create(id, commune)
 
   const {value} = await mongo.db.collection('bases_locales').findOneAndUpdate(
     {_id: mongo.parseObjectID(baseLocale._id)},
-    {$addToSet: {communes: codeCommune}},
+    {$addToSet: {communes: commune}},
     {returnOriginal: false}
   )
 
@@ -277,7 +285,7 @@ async function cleanCommune(id, codeCommune) {
     throw new Error('Base locale non trouvée')
   }
 
-  if (!baseLocale.communes.includes(codeCommune)) {
+  if (!hasCommune(baseLocale.communes, codeCommune)) {
     throw new Error('Commune non associée à la base locale')
   }
 
@@ -292,13 +300,14 @@ async function removeCommune(id, codeCommune) {
     throw new Error('Commune non trouvée')
   }
 
-  if (commune.status === 'ready-to-publish') {
+  const {code, status} = commune
+  if (status === 'ready-to-publish') {
     throw new Error('Impossible de supprimer une commune prête à être publiée')
   }
 
   const {value} = await mongo.db.collection('bases_locales').findOneAndUpdate(
     {_id: mongo.parseObjectID(id)},
-    {$pull: {communes: codeCommune}},
+    {$pull: {communes: {code, status}}},
     {returnOriginal: false}
   )
 
@@ -319,7 +328,7 @@ async function populateCommune(id, codeCommune) {
     throw new Error('Base locale non trouvée')
   }
 
-  if (!baseLocale.communes.includes(codeCommune)) {
+  if (!hasCommune(baseLocale.communes, codeCommune)) {
     throw new Error('Commune non associée à la base locale')
   }
 
@@ -365,7 +374,10 @@ async function importFile(id, file) {
   await cleanContent(id)
 
   // Set communes
-  const communes = uniqBy(voies, v => v.commune).map(v => v.commune)
+  const codesCommunes = uniqBy(voies, v => v.commune).map(v => v.commune)
+  const communes = codesCommunes.map(code => {
+    return {code, status: 'draft'}
+  })
   await mongo.db.collection('bases_locales').updateOne(
     {_id: mongo.parseObjectID(id)},
     {$set: {communes}}

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -15,6 +15,7 @@ const {extractFromCsv} = require('../populate/extract-csv')
 const adressesToCsv = require('../export/csv-bal').exportAsCsv
 const {transformToGeoJSON} = require('../export/geojson')
 const {getNomCommune, getCodesCommunes} = require('../util/cog')
+const Commune = require('./commune')
 const Voie = require('./voie')
 const Numero = require('./numero')
 
@@ -34,8 +35,7 @@ async function create(payload) {
     emails,
     enableComplement,
     token: generateBase62String(20),
-    communes: [],
-    status: 'draft'
+    communes: []
   }
 
   mongo.decorateCreation(baseLocale)
@@ -71,13 +71,15 @@ async function createDemo(payload) {
     token: generateBase62String(20),
     communes: [commune],
     nom: `Adresses de ${getNomCommune(commune)} [démo]`,
-    status: 'demo'
+    isDemo: true
   }
 
   mongo.decorateCreation(baseLocale)
 
   const {insertedId} = await mongo.db.collection('bases_locales').insertOne(baseLocale)
   baseLocale._id = insertedId
+
+  await Commune.create(baseLocale._id, {code: commune, status: 'demo'})
 
   if (populate) {
     await populateCommune(baseLocale._id, commune)
@@ -88,7 +90,6 @@ async function createDemo(payload) {
 
 const updateSchema = Joi.object().keys({
   nom: Joi.string().max(200).allow(null),
-  status: Joi.string().valid('draft', 'ready-to-publish'),
   emails: Joi.array().min(1).items(
     Joi.string().email()
   ),
@@ -134,17 +135,23 @@ async function transformToDraft(currentBaseLocale, payload) {
     throw new Error('A BaseLocale must be provided as first param')
   }
 
-  if (currentBaseLocale.status !== 'demo') {
-    throw new Error(`Cannot transform BaseLocale into draft. Expected status demo. Found: ${currentBaseLocale.status}`)
+  if (!currentBaseLocale.isDemo) {
+    throw new Error('Cannot transform a baseLocale that is not a demo.')
   }
 
   const {nom, email} = validPayload(payload, transformToDraftSchema)
 
   const changes = {
     nom: nom ? nom : `Adresses de ${getNomCommune(currentBaseLocale.communes[0])}`,
-    status: 'draft',
-    emails: [email]
+    emails: [email],
+    isDemo: false
   }
+
+  await mongo.db.collection('communes').updateMany(
+    {_bal: mongo.parseObjectID(currentBaseLocale._id)},
+    {$set: {status: 'draft'}},
+    {returnOriginal: false}
+  )
 
   mongo.decorateModification(changes)
 
@@ -195,12 +202,13 @@ async function renewToken(id) {
 }
 
 async function addCommune(id, codeCommune) {
-  if (!communes.some(c => c.code === codeCommune && ['commune-actuelle', 'arrondissement-municipal'].includes(c.type))) {
-    throw new Error('Code commune inconnu')
-  }
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id: id})
+  const status = baseLocale.isDemo ? 'demo' : 'draft'
+
+  await Commune.create(id, {code: codeCommune, status})
 
   const {value} = await mongo.db.collection('bases_locales').findOneAndUpdate(
-    {_id: mongo.parseObjectID(id)},
+    {_id: mongo.parseObjectID(baseLocale._id)},
     {$addToSet: {communes: codeCommune}},
     {returnOriginal: false}
   )
@@ -243,6 +251,7 @@ async function removeCommune(id, codeCommune) {
     throw new Error('BaseLocale not found')
   }
 
+  await mongo.db.collection('communes').deleteOne({code: codeCommune, _bal: mongo.parseObjectID(id)})
   await cleanContent(id, {commune: codeCommune})
 
   return value
@@ -260,6 +269,7 @@ async function populateCommune(id, codeCommune) {
   }
 
   await cleanCommune(id, codeCommune)
+  await Commune.create(id, {code: codeCommune})
   const {numeros, voies} = await extract(codeCommune)
   await Promise.all([
     Voie.importMany(mongo.parseObjectID(id), voies, {validate: false, keepIds: true}),
@@ -271,6 +281,7 @@ async function populateCommune(id, codeCommune) {
 
 async function cleanContent(id, query = {}) {
   await Promise.all([
+    mongo.db.collection('communes').deleteMany({_bal: mongo.parseObjectID(id)}),
     mongo.db.collection('voies').deleteMany({...query, _bal: mongo.parseObjectID(id)}),
     mongo.db.collection('numeros').deleteMany({...query, _bal: mongo.parseObjectID(id)})
   ])
@@ -307,6 +318,7 @@ async function importFile(id, file) {
 
   // Import new voies and numeros
   await Promise.all([
+    Commune.importMany(mongo.parseObjectID(id), communes, {validate: false, keepIds: true}),
     Voie.importMany(mongo.parseObjectID(id), voies, {validate: false, keepIds: true}),
     Numero.importMany(mongo.parseObjectID(id), numeros, {validate: false})
   ])

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -416,14 +416,15 @@ async function computeStats() {
   const response = await got('https://backend.adresse.data.gouv.fr/publication/submissions/published', {responseType: 'json'})
   const publishedBasesLocalesIds = new Set(response.body.map(b => b.url.slice(54, 78)))
 
-  const results = await mongo.db.collection('bases_locales').aggregate([
+  const results = await mongo.db.collection('communes').aggregate([
     {$match: {status: {$ne: 'demo'}}},
-    {$unwind: '$communes'},
-    {$group: {
-      _id: '$communes',
-      basesLocalesIds: {$addToSet: '$_id'},
-      statuses: {$addToSet: '$status'}
-    }}
+    {
+      $group: {
+        _id: '$code',
+        basesLocalesIds: {$addToSet: '$_bal'},
+        statuses: {$addToSet: '$status'}
+      }
+    }
   ]).toArray()
 
   function getStatus(communeResult) {
@@ -441,14 +442,14 @@ async function computeStats() {
   return {
     type: 'FeatureCollection',
     features: results
-      .filter(r => getContourCommune(r._id))
-      .map(r => {
-        const contourCommune = getContourCommune(r._id)
+      .filter(c => getContourCommune(c._id))
+      .map(c => {
+        const contourCommune = getContourCommune(c._id)
         const {nom, code} = contourCommune.properties
         const properties = {
           code,
           nom,
-          maxStatus: getStatus(r)
+          maxStatus: getStatus(c)
         }
         return {
           type: 'Feature',

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -1,4 +1,3 @@
-const communes = require('@etalab/decoupage-administratif/data/communes.json')
 const Joi = require('joi')
 const got = require('got')
 const {omit, uniqBy, difference} = require('lodash')
@@ -180,6 +179,15 @@ async function fetchByCommunes(codesCommunes) {
 }
 
 async function remove(id) {
+  const communes = await mongo.db.collection('communes').find({
+    _bal: mongo.parseObjectID(id),
+    $or: [{status: 'published'}, {status: 'ready-to-publish'}]
+  }).toArray()
+
+  if (communes.length > 0) {
+    throw new Error('Impossible de supprimer une Base Locale possèdant ou des communes publiées ou prêtes à être publiées')
+  }
+
   await mongo.db.collection('bases_locales').deleteOne({_id: mongo.parseObjectID(id)})
   await cleanContent(id)
 }
@@ -279,8 +287,13 @@ async function cleanCommune(id, codeCommune) {
 }
 
 async function removeCommune(id, codeCommune) {
-  if (!communes.some(c => c.code === codeCommune)) {
-    throw new Error('Code commune inconnu')
+  const commune = await mongo.db.collection('communes').findOne({_bal: id, code: codeCommune})
+  if (!commune) {
+    throw new Error('Commune non trouvée')
+  }
+
+  if (commune.status === 'ready-to-publish') {
+    throw new Error('Impossible de supprimer une commune prête à être publiée')
   }
 
   const {value} = await mongo.db.collection('bases_locales').findOneAndUpdate(

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -203,6 +203,15 @@ async function renewToken(id) {
 
 async function addCommune(id, codeCommune) {
   const baseLocale = await mongo.db.collection('bases_locales').findOne({_id: id})
+
+  if (!baseLocale) {
+    throw new Error('Base locale non trouvée')
+  }
+
+  if (baseLocale.communes.includes(codeCommune)) {
+    throw new Error('Cette commune existe déjà dans cette base locale')
+  }
+
   const status = baseLocale.isDemo ? 'demo' : 'draft'
 
   await Commune.create(id, {code: codeCommune, status})
@@ -212,10 +221,6 @@ async function addCommune(id, codeCommune) {
     {$addToSet: {communes: codeCommune}},
     {returnOriginal: false}
   )
-
-  if (!value) {
-    throw new Error('BaseLocale not found')
-  }
 
   return value
 }

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -235,6 +235,33 @@ async function addCommune(id, codeCommune) {
   return value
 }
 
+async function updateCommuneStatus(baseLocale, codeCommune, status) {
+  if (baseLocale.isDemo) {
+    throw new Error('Impossible de modifier le statut d’une commune d’une Base Locale de démonstration')
+  }
+
+  const commune = await mongo.db.collection('communes').findOne({_bal: baseLocale._id, code: codeCommune})
+  if (!commune) {
+    throw new Error('Commune non trouvée')
+  }
+
+  // Status evolution
+  // demo -> draft <-> ready-to-publish -> published
+  if (commune.status === 'published') {
+    throw new Error('Impossible de changer le status d’une Base Locale publiée')
+  }
+
+  if (status === 'ready-to-publish' && commune.status !== 'draft') {
+    throw new Error('Seule une commune en brouillon peut passer au statut "Prête à être publiée"')
+  }
+
+  if (status === 'published' && commune.status !== 'ready-to-publish') {
+    throw new Error('Seule une commune prête à être publiée peut être publiée')
+  }
+
+  return Commune.update(commune._id, {status})
+}
+
 async function cleanCommune(id, codeCommune) {
   const baseLocale = await mongo.db.collection('bases_locales').findOne({_id: id})
 
@@ -417,6 +444,7 @@ module.exports = {
   renewToken,
   getCommune,
   addCommune,
+  updateCommuneStatus,
   cleanCommune,
   removeCommune,
   populateCommune,

--- a/lib/models/commune.js
+++ b/lib/models/commune.js
@@ -1,0 +1,122 @@
+const communes = require('@etalab/decoupage-administratif/data/communes.json')
+const Joi = require('joi')
+const {validPayload} = require('../util/payload')
+const mongo = require('../util/mongo')
+
+const validCodeCommune = (codeCommune, helpers) => {
+  if (!communes.some(c => c.code === codeCommune && ['commune-actuelle', 'arrondissement-municipal'].includes(c.type))) {
+    return helpers.error('any.invalid')
+  }
+
+  return codeCommune
+}
+
+const createSchema = Joi.object().keys({
+  code: Joi.string().custom(validCodeCommune, 'code validation').required(),
+  status: Joi.string().valid('demo', 'draft')
+})
+
+async function create(idBal, payload) {
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id: idBal})
+
+  if (!baseLocale) {
+    throw new Error('Base locale non trouvée')
+  }
+
+  const {code, status} = validPayload(payload, createSchema)
+
+  const commune = {
+    code,
+    _bal: idBal,
+    status: status || 'draft'
+  }
+
+  mongo.decorateCreation(commune)
+
+  const {insertedId} = await mongo.db.collection('communes').insertOne(commune)
+  commune._id = insertedId
+
+  await mongo.touchDocument('bases_locales', commune._bal, commune._created)
+
+  return commune
+}
+
+const updateSchema = Joi.object().keys({
+  status: Joi.string().valid('draft', 'ready-to-publish')
+})
+
+async function update(id, payload) {
+  const communeChanges = validPayload(payload, updateSchema)
+
+  mongo.decorateModification(communeChanges)
+
+  const {value} = await mongo.db.collection('communes').findOneAndUpdate(
+    {_id: mongo.parseObjectID(id)},
+    {$set: communeChanges},
+    {returnOriginal: false}
+  )
+
+  if (!value) {
+    throw new Error('Commune not found')
+  }
+
+  await mongo.touchDocument('bases_locales', value._bal, value._updated)
+
+  return value
+}
+
+async function importMany(idBal, rawCommunes, options = {}) {
+  if (!idBal) {
+    throw new Error('idBal is required')
+  }
+
+  if (options.validate !== false) {
+    throw new Error('Validation is not currently available in importMany')
+  }
+
+  const communes = rawCommunes
+    .map(c => {
+      if (!c.code) {
+        return null
+      }
+
+      const commune = {
+        _bal: idBal,
+        code: c.code,
+        status: c.status || 'draft'
+      }
+
+      if (options.keepIds) {
+        commune._id = c._id
+      }
+
+      if (c._updated && c._created) {
+        commune._created = c._created
+        commune._updated = c._updated
+      } else {
+        mongo.decorateCreation(commune)
+      }
+
+      return commune
+    })
+    .filter(Boolean)
+
+  if (communes.length === 0) {
+    return
+  }
+
+  await mongo.db.collection('communes').insertMany(communes)
+}
+
+async function fetchOne(id) {
+  return mongo.db.collection('communes').findOne({_id: mongo.parseObjectID(id)})
+}
+
+module.exports = {
+  create,
+  createSchema,
+  update,
+  updateSchema,
+  importMany,
+  fetchOne
+}

--- a/lib/models/commune.js
+++ b/lib/models/commune.js
@@ -17,7 +17,7 @@ const createSchema = Joi.object().keys({
 })
 
 async function create(idBal, payload) {
-  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id: idBal})
+  const baseLocale = await mongo.db.collection('bases_locales').findOne({_id: mongo.parseObjectID(idBal)})
 
   if (!baseLocale) {
     throw new Error('Base locale non trouvée')

--- a/lib/models/commune.js
+++ b/lib/models/commune.js
@@ -42,7 +42,7 @@ async function create(idBal, payload) {
 }
 
 const updateSchema = Joi.object().keys({
-  status: Joi.string().valid('draft', 'ready-to-publish')
+  status: Joi.string().valid('draft', 'ready-to-publish', 'published')
 })
 
 async function update(id, payload) {

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -30,7 +30,7 @@ function getApp() {
 }
 
 const GENERATED_VARS = ['_id', '_updated', '_created', 'token']
-const KEYS = ['nom', 'emails', 'token', '_updated', '_created', '_id', 'communes', 'status', 'enableComplement']
+const KEYS = ['nom', 'emails', 'token', '_updated', '_created', '_id', 'communes', 'enableComplement']
 const SAFE_FIELDS = ['nom', '_updated', '_created', '_id', 'communes', 'enableComplement']
 
 test.serial('create a BaseLocale', async t => {
@@ -45,7 +45,6 @@ test.serial('create a BaseLocale', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    status: 'draft',
     communes: []
   })
   t.true(KEYS.every(k => k in body))
@@ -108,7 +107,6 @@ test.serial('get a BaseLocal / with admin token', async t => {
     emails: ['me@domain.co'],
     enableComplement: false,
     communes: [],
-    status: 'draft',
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -225,7 +223,7 @@ test.serial('modify a BaseLocal / demo', async t => {
     enableComplement: false,
     communes: ['27115'],
     token: 'coucou',
-    status: 'demo',
+    isDemo: true,
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -251,7 +249,6 @@ test.serial('transform BaseLocal to draft / not a demo', async t => {
     enableComplement: false,
     communes: ['27115'],
     token: 'coucou',
-    status: 'draft',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
@@ -361,7 +358,7 @@ test.serial('add a commune to a BaseLocal / invalid commune', async t => {
     .put(`/bases-locales/${_id}/communes/12345`)
     .set({Authorization: 'Token coucou'})
 
-  t.is(status, 500)
+  t.is(status, 400)
 })
 
 test.serial('add a commune to a BaseLocal / without admin token', async t => {

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -221,7 +221,7 @@ test.serial('modify a BaseLocal / demo', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     isDemo: true,
     _created: new Date('2019-01-01'),
@@ -247,7 +247,7 @@ test.serial('transform BaseLocal to draft / not a demo', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -338,7 +338,7 @@ test.serial('add a commune to a BaseLocal / with admin token', async t => {
 
   t.is(status, 200)
   t.is(body.communes.length, 1)
-  t.is(body.communes[0], '27115')
+  t.deepEqual(body.communes[0], {code: '27115', status: 'draft'})
 })
 
 test.serial('add a commune to a BaseLocal / invalid commune', async t => {
@@ -387,7 +387,7 @@ test.serial('set commune as draft / with admin token', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -417,7 +417,7 @@ test.serial('set commune as draft / without admin token', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -447,7 +447,7 @@ test.serial('set commune as ready to publish / with admin token', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -478,7 +478,7 @@ test.serial('set commune as ready to publish / without admin token', async t => 
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -508,7 +508,7 @@ test.serial('publish commune / with admin token', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -538,7 +538,7 @@ test.serial('publish commune / without admin token', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -568,7 +568,7 @@ test.serial('remove a commune from a BaseLocal / with admin token', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115', status: 'draft'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -598,7 +598,7 @@ test.serial('remove a commune from a BaseLocal / invalid commune', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -618,7 +618,7 @@ test.serial('remove a commune from a BaseLocal / without admin token', async t =
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -629,7 +629,7 @@ test.serial('remove a commune from a BaseLocal / without admin token', async t =
 
   t.is(status, 403)
   const baseLocal = await mongo.db.collection('bases_locales').findOne({_id})
-  t.deepEqual(baseLocal.communes, ['27115'])
+  t.deepEqual(baseLocal.communes, [{code: '27115'}])
 })
 
 test('export as CSV', async t => {
@@ -669,7 +669,7 @@ test.serial('renew token / with admin token', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -690,7 +690,7 @@ test.serial('renew token / invalid balId', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -710,7 +710,7 @@ test.serial('renew token / without admin token', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['27115'],
+    communes: [{code: '27115'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -573,6 +573,15 @@ test.serial('remove a commune from a BaseLocal / with admin token', async t => {
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommune,
+    _bal: _id,
+    code: '27115',
+    status: 'draft',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
 
   const {body, status} = await request(getApp())
     .delete(`/bases-locales/${_id}/communes/27115`)

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -380,6 +380,187 @@ test.serial('add a commune to a BaseLocal / without admin token', async t => {
   t.is(status, 403)
 })
 
+test.serial('set commune as draft / with admin token', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    enableComplement: false,
+    communes: ['27115'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommune,
+    _bal: _id,
+    code: '27115',
+    status: 'ready-to-publish',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {body, status} = await request(getApp())
+    .post(`/bases-locales/${_id}/communes/27115/set-as-draft`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  t.is(body.status, 'draft')
+})
+
+test.serial('set commune as draft / without admin token', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    enableComplement: false,
+    communes: ['27115'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommune,
+    _bal: _id,
+    code: '27115',
+    status: 'ready-to-publish',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status} = await request(getApp())
+    .post(`/bases-locales/${_id}/communes/27115/set-as-draft`)
+
+  t.is(status, 403)
+  const commune = await mongo.db.collection('communes').findOne({_id: _idCommune})
+  t.is(commune.status, 'ready-to-publish')
+})
+
+test.serial('set commune as ready to publish / with admin token', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    enableComplement: false,
+    communes: ['27115'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommune,
+    _bal: _id,
+    code: '27115',
+    status: 'draft',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {body, status} = await request(getApp())
+    .post(`/bases-locales/${_id}/communes/27115/set-as-ready-to-publish`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  t.is(body.code, '27115')
+  t.is(body.status, 'ready-to-publish')
+})
+
+test.serial('set commune as ready to publish / without admin token', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    enableComplement: false,
+    communes: ['27115'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommune,
+    _bal: _id,
+    code: '27115',
+    status: 'draft',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status} = await request(getApp())
+    .post(`/bases-locales/${_id}/communes/27115/set-as-ready-to-publish`)
+
+  t.is(status, 403)
+  const commune = await mongo.db.collection('communes').findOne({_id: _idCommune})
+  t.is(commune.status, 'draft')
+})
+
+test.serial('publish commune / with admin token', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    enableComplement: false,
+    communes: ['27115'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommune,
+    _bal: _id,
+    code: '27115',
+    status: 'ready-to-publish',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {body, status} = await request(getApp())
+    .post(`/bases-locales/${_id}/communes/27115/publish`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  t.is(body.status, 'published')
+})
+
+test.serial('publish commune / without admin token', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    enableComplement: false,
+    communes: ['27115'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  const _idCommune = new mongo.ObjectID()
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommune,
+    _bal: _id,
+    code: '27115',
+    status: 'ready-to-publish',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status} = await request(getApp())
+    .post(`/bases-locales/${_id}/communes/27115/publish`)
+
+  t.is(status, 403)
+  const commune = await mongo.db.collection('communes').findOne({_id: _idCommune})
+  t.is(commune.status, 'ready-to-publish')
+})
+
 test.serial('remove a commune from a BaseLocal / with admin token', async t => {
   const _id = new mongo.ObjectID()
   await mongo.db.collection('bases_locales').insertOne({

--- a/lib/routes/__tests__/stats.js
+++ b/lib/routes/__tests__/stats.js
@@ -101,42 +101,39 @@ test.serial('get Bases Locales with code departement / invalid code departement'
 })
 
 test.serial('get couverture BAL', async t => {
-  const _idBalA = new mongo.ObjectID()
-  const _idBalB = new mongo.ObjectID()
-  const _idBalC = new mongo.ObjectID()
+  const _idCommuneA = new mongo.ObjectID()
+  const _idCommuneB = new mongo.ObjectID()
+  const _idCommuneC = new mongo.ObjectID()
+  const _idCommuneD = new mongo.ObjectID()
 
-  await mongo.db.collection('bases_locales').insertOne({
-    _id: _idBalA,
-    nom: 'foo',
-    emails: ['me@domain.co'],
-    enableComplement: false,
-    communes: [{code: '54084'}],
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommuneA,
+    code: '54084',
     status: 'ready-to-publish',
-    token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
 
-  await mongo.db.collection('bases_locales').insertOne({
-    _id: _idBalB,
-    nom: 'foo',
-    emails: ['me@domain.co'],
-    enableComplement: false,
-    communes: [{code: '57222'}],
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommuneB,
+    code: '57222',
     status: 'draft',
-    token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })
 
-  await mongo.db.collection('bases_locales').insertOne({
-    _id: _idBalC,
-    nom: 'foo',
-    published: true,
-    emails: ['me@domain.co'],
-    enableComplement: false,
-    communes: [{code: '69123'}],
-    token: 'coucou',
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommuneC,
+    code: '69123',
+    status: 'published',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  await mongo.db.collection('communes').insertOne({
+    _id: _idCommuneD,
+    code: '27115',
+    status: 'demo',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
   })

--- a/lib/routes/__tests__/stats.js
+++ b/lib/routes/__tests__/stats.js
@@ -43,7 +43,7 @@ test.serial('get Bases Locales with a code departement', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['54084'],
+    communes: [{code: '54084'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -54,7 +54,7 @@ test.serial('get Bases Locales with a code departement', async t => {
     nom: 'fobaro',
     emails: ['you@domain.tld'],
     enableComplement: false,
-    communes: ['54222'],
+    communes: [{code: '54222'}],
     token: 'hello',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -65,7 +65,7 @@ test.serial('get Bases Locales with a code departement', async t => {
     nom: 'fobaro',
     emails: ['you@domain.tld'],
     enableComplement: false,
-    communes: ['33345'],
+    communes: [{code: '33345'}],
     token: 'hello',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -87,7 +87,7 @@ test.serial('get Bases Locales with code departement / invalid code departement'
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['54084'],
+    communes: [{code: '54084'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -110,7 +110,7 @@ test.serial('get couverture BAL', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['54084'],
+    communes: [{code: '54084'}],
     status: 'ready-to-publish',
     token: 'coucou',
     _created: new Date('2019-01-01'),
@@ -122,7 +122,7 @@ test.serial('get couverture BAL', async t => {
     nom: 'foo',
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['57222'],
+    communes: [{code: '57222'}],
     status: 'draft',
     token: 'coucou',
     _created: new Date('2019-01-01'),
@@ -135,7 +135,7 @@ test.serial('get couverture BAL', async t => {
     published: true,
     emails: ['me@domain.co'],
     enableComplement: false,
-    communes: ['69123'],
+    communes: [{code: '69123'}],
     token: 'coucou',
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -129,6 +129,12 @@ app.route('/bases-locales/:baseLocaleId/csv')
     res.attachment('bal.csv').type('csv').send(csvFile)
   }))
 
+app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/csv')
+  .get(w(async (req, res) => {
+    const csvFile = await BaseLocale.exportCommuneAsCsv(req.baseLocale._id, req.params.codeCommune)
+    res.attachment('bal.csv').type('csv').send(csvFile)
+  }))
+
 app.route('/bases-locales/:baseLocaleId/communes/:codeCommune')
   .get(w(async (req, res) => {
     res.send(BaseLocale.getCommune(req.baseLocale._id, req.params.codeCommune))

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -88,7 +88,7 @@ app.route('/bases-locales/:baseLocaleId')
     }
   }))
   .put(ensureIsAdmin, w(async (req, res) => {
-    if (req.baseLocale.status === 'demo') {
+    if (req.baseLocale.isDemo) {
       return res.status(403).send({code: 403, message: 'Une Base Adresse Locale de démonstration ne peut pas être modifiée. Elle doit d’abord être transformée en brouillon.'})
     }
 
@@ -102,7 +102,7 @@ app.route('/bases-locales/:baseLocaleId')
 
 app.route('/bases-locales/:baseLocaleId/transform-to-draft')
   .post(ensureIsAdmin, w(async (req, res) => {
-    if (req.baseLocale.status !== 'demo') {
+    if (!req.baseLocale.isDemo) {
       return res.status(403).send({
         code: 403,
         message: 'La Base Adresse Locale n’est pas une Base Adresse Locale de démonstration'

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -130,6 +130,9 @@ app.route('/bases-locales/:baseLocaleId/csv')
   }))
 
 app.route('/bases-locales/:baseLocaleId/communes/:codeCommune')
+  .get(w(async (req, res) => {
+    res.send(BaseLocale.getCommune(req.baseLocale._id, req.params.codeCommune))
+  }))
   .put(ensureIsAdmin, w(async (req, res) => {
     const baseLocale = await BaseLocale.addCommune(req.baseLocale._id, req.params.codeCommune)
     res.send(baseLocale)

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -142,6 +142,24 @@ app.route('/bases-locales/:baseLocaleId/communes/:codeCommune')
     res.send(baseLocale)
   }))
 
+app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/set-as-draft')
+  .post(ensureIsAdmin, w(async (req, res) => {
+    const commune = await BaseLocale.updateCommuneStatus(req.baseLocale, req.params.codeCommune, 'draft')
+    res.send(commune)
+  }))
+
+app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/set-as-ready-to-publish')
+  .post(ensureIsAdmin, w(async (req, res) => {
+    const commune = await BaseLocale.updateCommuneStatus(req.baseLocale, req.params.codeCommune, 'ready-to-publish')
+    res.send(commune)
+  }))
+
+app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/publish')
+  .post(ensureIsAdmin, w(async (req, res) => {
+    const commune = await BaseLocale.updateCommuneStatus(req.baseLocale, req.params.codeCommune, 'published')
+    res.send(commune)
+  }))
+
 app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/geojson')
   .get(w(async (req, res) => {
     const geojsonStream = await BaseLocale.streamToGeoJSON(req.baseLocale._id, req.params.codeCommune)

--- a/mongo.indexes.js
+++ b/mongo.indexes.js
@@ -1,4 +1,9 @@
 module.exports = {
+  communes: [
+    {_bal: 1},
+    {_bal: 1, code: 1}
+  ],
+
   voies: [
     {_bal: 1},
     {_bal: 1, commune: 1}


### PR DESCRIPTION
Ajout du modèle `Commune` et migre le `status` du modèle `BaseLocale` à `Commune`.

Cette modification vient préparer le terrain d'une publication à l'échelle communale.

### Modèle commune
```
{
  _bal: {idBal}
  code: 'xxxxx',
  status: 'status',
  _created: {date}
  _updatedd {date}
}
```

### Modifications du modèle BaseLocale
- communes: `[codeCommune, ...]` -> `[{code, status}, ...]`
- status -> `isDemo`

### Nouvelles routes
`[GET] /bases-locales/:baseLocaleId/communes/:codeCommune`
`[GET] /bases-locales/:baseLocaleId/communes/:codeCommune/csv`
`[POST] /bases-locales/:baseLocaleId/communes/:codeCommune/set-as-draft`
`[POST] /bases-locales/:baseLocaleId/communes/:codeCommune/set-as-ready-to-publish`
`[POST] /bases-locales/:baseLocaleId/communes/:codeCommune/publish`