### PR TITLE
Envoi d'un email de récupération des BAL d'un utilisateur

### DIFF
--- a/lib/emails/__tests__/recovery-notification.js
+++ b/lib/emails/__tests__/recovery-notification.js
@@ -44,6 +44,10 @@ test('formatEmail', t => {
       margin: 1em 0;
     }
 
+    h5 {
+      margin: 40px 0 0;
+    }
+
     img {
       max-height: 45px;
       background-color: #F5F6F7;
@@ -83,6 +87,11 @@ test('formatEmail', t => {
       background-color: rgb(212, 238, 226);
       color: rgb(0, 120, 62);
     }
+
+    .explaination {
+      font-size: small;
+    }
+
   </style>
 </head>
 
@@ -100,7 +109,13 @@ test('formatEmail', t => {
     <ul>
       <li><span class="status draft">Brouillon</span> BAL A : <a href="http://editor.domain.tld/21/123456">http://editor.domain.tld/21/123456</a></li><li><span class="status ready-to-publish">Prête à être publiée</span> BAL B : <a href="http://editor.domain.tld/42/789100">http://editor.domain.tld/42/789100</a></li><li><span class="status published">Publiée</span> BAL C : <a href="http://editor.domain.tld/84/424242">http://editor.domain.tld/84/424242</a></li>
     </ul>
-    <span><i>L’équipe adresse.data.gouv.fr</i></span>
+
+    <h5>Pourquoi ce courriel vous est envoyé ?</h5>
+    <p class="explaination">
+      Une personne souhaite récupérer l’accès à ses Bases Adresses Locales et a communiquée cette adresse de courrier électronique.
+      Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer ce courriel.
+    </p>
+
   </div>
 </body>
 

--- a/lib/emails/__tests__/recovery-notification.js
+++ b/lib/emails/__tests__/recovery-notification.js
@@ -92,6 +92,9 @@ test('formatEmail', t => {
       font-size: small;
     }
 
+    .signature {
+      margin-top: 40px;
+    }
   </style>
 </head>
 
@@ -105,7 +108,7 @@ test('formatEmail', t => {
   </div>
 
   <div class="container">
-    <div>Liste des Bases Adresses Locales associées à votre adresse email :</div>
+    <h3>Liste des Bases Adresses Locales associées à votre adresse email :</h3>
     <ul>
       <li><span class="status draft">Brouillon</span> BAL A : <a href="http://editor.domain.tld/21/123456">http://editor.domain.tld/21/123456</a></li><li><span class="status ready-to-publish">Prête à être publiée</span> BAL B : <a href="http://editor.domain.tld/42/789100">http://editor.domain.tld/42/789100</a></li><li><span class="status published">Publiée</span> BAL C : <a href="http://editor.domain.tld/84/424242">http://editor.domain.tld/84/424242</a></li>
     </ul>
@@ -116,6 +119,7 @@ test('formatEmail', t => {
       Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer ce courriel.
     </p>
 
+    <div class="signature"><i>L’équipe adresse.data.gouv.fr</i></div>
   </div>
 </body>
 

--- a/lib/emails/__tests__/recovery-notification.js
+++ b/lib/emails/__tests__/recovery-notification.js
@@ -1,0 +1,111 @@
+const test = require('ava')
+const formatEmail = require('../recovery-notification')
+
+test('formatEmail', t => {
+  const basesLocales = [
+    {
+      _id: '21',
+      token: '123456',
+      status: 'draft',
+      nom: 'BAL A'
+    },
+    {
+      _id: '42',
+      token: '789100',
+      status: 'ready-to-publish',
+      nom: 'BAL B'
+    },
+    {
+      _id: '84',
+      token: '424242',
+      status: 'published',
+      nom: 'BAL C'
+    }
+  ]
+
+  const expectedTextBody = `
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demande de récupération de vos Bases Adresses Locales</title>
+  <style>
+    body {
+      background-color: #F5F6F7;
+      color: #234361;
+      font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      margin: auto;
+      padding: 25px;
+    }
+
+    li {
+      margin: 1em 0;
+    }
+
+    img {
+      max-height: 45px;
+      background-color: #F5F6F7;
+    }
+
+    .container {
+      background-color: #ebeff3;
+      padding: 25px;
+    }
+
+    .title {
+      align-items: center;
+      border-bottom: 1px solid #E4E7EB;
+      justify-content: center;
+      margin-top: 35px;
+      min-height: 10em;
+      padding: 10px;
+      text-align: center;
+    }
+
+    .status {
+      padding: .4em;
+      border-radius: 4px;
+    }
+
+    .draft {
+      background-color: rgb(228, 231, 235);
+      color: rgb(66, 90, 112);
+    }
+
+    .ready-to-publish {
+      background-color: rgb(221, 235, 247);
+      color: rgb(8, 75, 138);
+    }
+
+    .published {
+      background-color: rgb(212, 238, 226);
+      color: rgb(0, 120, 62);
+    }
+  </style>
+</head>
+
+<body>
+  <div>
+    <img src="http://api.domain.tld/public/images/logo-adresse.png" alt="Logo République Française">
+  </div>
+  <div class="title">
+    <h2 style="margin:0; mso-line-height-rule:exactly;">Demande de récupération de vos Bases Adresses Locales</h2><br>
+    <h3 style="margin:0; mso-line-height-rule:exactly;">Cliquez sur le lien associé pour récupérer une Base Adresse Locale</h3>
+  </div>
+
+  <div class="container">
+    <div>Liste des Bases Adresses Locales associées à votre adresse email :</div>
+    <ul>
+      <li><span class="status draft">Brouillon</span> BAL A : <a href="http://editor.domain.tld/21/123456">http://editor.domain.tld/21/123456</a></li><li><span class="status ready-to-publish">Prête à être publiée</span> BAL B : <a href="http://editor.domain.tld/42/789100">http://editor.domain.tld/42/789100</a></li><li><span class="status published">Publiée</span> BAL C : <a href="http://editor.domain.tld/84/424242">http://editor.domain.tld/84/424242</a></li>
+    </ul>
+    <span><i>L’équipe adresse.data.gouv.fr</i></span>
+  </div>
+</body>
+
+</html>
+`
+
+  t.is(formatEmail({basesLocales}).html, expectedTextBody)
+})

--- a/lib/emails/recovery-notification.js
+++ b/lib/emails/recovery-notification.js
@@ -1,0 +1,111 @@
+const {template} = require('lodash')
+const {getEditorUrl, getApiUrl} = require('./util')
+
+const bodyTemplate = template(`
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demande de récupération de vos Bases Adresses Locales</title>
+  <style>
+    body {
+      background-color: #F5F6F7;
+      color: #234361;
+      font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      margin: auto;
+      padding: 25px;
+    }
+
+    li {
+      margin: 1em 0;
+    }
+
+    img {
+      max-height: 45px;
+      background-color: #F5F6F7;
+    }
+
+    .container {
+      background-color: #ebeff3;
+      padding: 25px;
+    }
+
+    .title {
+      align-items: center;
+      border-bottom: 1px solid #E4E7EB;
+      justify-content: center;
+      margin-top: 35px;
+      min-height: 10em;
+      padding: 10px;
+      text-align: center;
+    }
+
+    .status {
+      padding: .4em;
+      border-radius: 4px;
+    }
+
+    .draft {
+      background-color: rgb(228, 231, 235);
+      color: rgb(66, 90, 112);
+    }
+
+    .ready-to-publish {
+      background-color: rgb(221, 235, 247);
+      color: rgb(8, 75, 138);
+    }
+
+    .published {
+      background-color: rgb(212, 238, 226);
+      color: rgb(0, 120, 62);
+    }
+  </style>
+</head>
+
+<body>
+  <div>
+    <img src="<%= apiUrl %>/public/images/logo-adresse.png" alt="Logo République Française">
+  </div>
+  <div class="title">
+    <h2 style="margin:0; mso-line-height-rule:exactly;">Demande de récupération de vos Bases Adresses Locales</h2><br>
+    <h3 style="margin:0; mso-line-height-rule:exactly;">Cliquez sur le lien associé pour récupérer une Base Adresse Locale</h3>
+  </div>
+
+  <div class="container">
+    <div>Liste des Bases Adresses Locales associées à votre adresse email :</div>
+    <ul>
+      <% _.forEach(basesLocalesRevory, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }); %>
+    </ul>
+    <span><i>L’équipe adresse.data.gouv.fr</i></span>
+  </div>
+</body>
+
+</html>
+`)
+
+const STATUS = {
+  draft: 'Brouillon',
+  'ready-to-publish': 'Prête à être publiée',
+  published: 'Publiée'
+}
+
+function formatEmail(data) {
+  const {basesLocales} = data
+  const apiUrl = getApiUrl()
+  const basesLocalesRevory = basesLocales.map(baseLocale => {
+    return {
+      ...baseLocale,
+      statusFr: STATUS[baseLocale.status],
+      recoveryUrl: getEditorUrl(baseLocale)
+    }
+  })
+
+  return {
+    subject: 'Demande de récupération de vos Bases Adresses Locales',
+    html: bodyTemplate({basesLocalesRevory, apiUrl})
+  }
+}
+
+module.exports = formatEmail

--- a/lib/emails/recovery-notification.js
+++ b/lib/emails/recovery-notification.js
@@ -69,6 +69,10 @@ const bodyTemplate = template(`
     .explaination {
       font-size: small;
     }
+
+    .signature {
+      margin-top: 40px;
+    }
   </style>
 </head>
 
@@ -82,7 +86,7 @@ const bodyTemplate = template(`
   </div>
 
   <div class="container">
-    <div>Liste des Bases Adresses Locales associées à votre adresse email :</div>
+    <h3>Liste des Bases Adresses Locales associées à votre adresse email :</h3>
     <ul>
       <% _.forEach(basesLocalesRevory, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }); %>
     </ul>
@@ -92,6 +96,8 @@ const bodyTemplate = template(`
       Une personne souhaite récupérer l’accès à ses Bases Adresses Locales et a communiquée cette adresse de courrier électronique.
       Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer ce courriel.
     </p>
+
+    <div class="signature"><i>L’équipe adresse.data.gouv.fr</i></div>
   </div>
 </body>
 

--- a/lib/emails/recovery-notification.js
+++ b/lib/emails/recovery-notification.js
@@ -22,6 +22,10 @@ const bodyTemplate = template(`
       margin: 1em 0;
     }
 
+    h5 {
+      margin: 40px 0 0;
+    }
+
     img {
       max-height: 45px;
       background-color: #F5F6F7;
@@ -61,6 +65,10 @@ const bodyTemplate = template(`
       background-color: rgb(212, 238, 226);
       color: rgb(0, 120, 62);
     }
+
+    .explaination {
+      font-size: small;
+    }
   </style>
 </head>
 
@@ -78,7 +86,12 @@ const bodyTemplate = template(`
     <ul>
       <% _.forEach(basesLocalesRevory, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }); %>
     </ul>
-    <span><i>L’équipe adresse.data.gouv.fr</i></span>
+
+    <h5>Pourquoi ce courriel vous est envoyé ?</h5>
+    <p class="explaination">
+      Une personne souhaite récupérer l’accès à ses Bases Adresses Locales et a communiquée cette adresse de courrier électronique.
+      Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer ce courriel.
+    </p>
   </div>
 </body>
 

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -10,6 +10,7 @@ const {getContourCommune} = require('../util/contours-communes')
 const createTokenRenewalNotificationEmail = require('../emails/token-renewal-notification')
 const createBalCreationNotificationEmail = require('../emails/bal-creation-notification')
 const createNewAdminNotificationEmail = require('../emails/new-admin-notification')
+const createRecoveryNotificationEmail = require('../emails/recovery-notification')
 const {extract} = require('../populate/extract-ban')
 const {extractFromCsv} = require('../populate/extract-csv')
 const adressesToCsv = require('../export/csv-bal').exportAsCsv
@@ -374,6 +375,15 @@ async function computeStats() {
   }
 }
 
+async function basesLocalesRecovery(userEmail) {
+  const basesLocales = await mongo.db.collection('bases_locales').find({emails: userEmail}).toArray()
+
+  if (basesLocales.length > 0) {
+    const email = createRecoveryNotificationEmail({basesLocales})
+    await sendMail(email, [userEmail])
+  }
+}
+
 module.exports = {
   create,
   createSchema,
@@ -397,5 +407,6 @@ module.exports = {
   cleanContent,
   importFile,
   filterSensitiveFields,
-  computeStats
+  computeStats,
+  basesLocalesRecovery
 }

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -123,6 +123,12 @@ app.route('/bases-locales/:baseLocaleId/upload')
     res.send(result)
   }))
 
+app.route('/bases-locales/recovery')
+  .post(w(async (req, res) => {
+    await BaseLocale.basesLocalesRecovery(req.body.email)
+    res.sendStatus(200)
+  }))
+
 app.route('/bases-locales/:baseLocaleId/csv')
   .get(w(async (req, res) => {
     const csvFile = await BaseLocale.exportAsCsv(req.baseLocale._id)


### PR DESCRIPTION
Création d'une nouvelle route permettant l'envoi d'un mail contenant un lien d'administration pour toutes les Bases Adresses Locales associées à une adresse email.

### Route
`[POST] /bases-locales/recovery`

**body**
```
{email: 'user@mail.fr'}
```

---
![Capture d’écran 2021-01-25 à 12 02 11](https://user-images.githubusercontent.com/7040549/105697740-3db9e400-5f05-11eb-8f27-0ed23b7172ef.png)
