### PR TITLE
Obligation de renseigner "nom" lors de la création d'une BAL

### DIFF
--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -28,7 +28,7 @@ test('create a BaseLocale', async t => {
 })
 
 test('create a BaseLocale / minimal', async t => {
-  const baseLocale = await BaseLocale.create({emails: ['me@domain.co']})
+  const baseLocale = await BaseLocale.create({nom: 'foo', emails: ['me@domain.co']})
   const keys = ['nom', 'status', 'emails', 'token', '_updated', '_created', '_id', 'communes', 'enableComplement']
   t.true(keys.every(k => k in baseLocale))
   t.is(Object.keys(baseLocale).length, 9)

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -35,11 +35,23 @@ test('create a BaseLocale / minimal', async t => {
 })
 
 test('create a BaseLocale / without nom', async t => {
-  await t.throwsAsync(() => BaseLocale.create({emails: ['me@domain.co']}))
+  const error = await t.throwsAsync(() => BaseLocale.create({emails: ['me@domain.co']}))
+
+  t.deepEqual(error.validation, {
+    nom: ['"nom" is required']
+  })
+
+  t.is(error.message, 'Invalid payload')
 })
 
 test('create a BaseLocale / empty nom', async t => {
-  await t.throwsAsync(() => BaseLocale.create({nom: '', emails: ['me@domain.co']}))
+  const error = await t.throwsAsync(() => BaseLocale.create({nom: '', emails: ['me@domain.co']}))
+
+  t.deepEqual(error.validation, {
+    nom: ['"nom" is not allowed to be empty']
+  })
+
+  t.is(error.message, 'Invalid payload')
 })
 
 test('create a BaseLocale / demo', async t => {

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -34,6 +34,14 @@ test('create a BaseLocale / minimal', async t => {
   t.is(Object.keys(baseLocale).length, 9)
 })
 
+test('create a BaseLocale / without nom', async t => {
+  await t.throwsAsync(() => BaseLocale.create({emails: ['me@domain.co']}))
+})
+
+test('create a BaseLocale / empty nom', async t => {
+  await t.throwsAsync(() => BaseLocale.create({nom: '', emails: ['me@domain.co']}))
+})
+
 test('create a BaseLocale / demo', async t => {
   const baseLocale = await BaseLocale.createDemo({
     commune: '27115',

--- a/lib/models/__tests__/base-locale.schema.js
+++ b/lib/models/__tests__/base-locale.schema.js
@@ -15,12 +15,23 @@ test('valid payload', t => {
 
 test('valid payload: minimalist', t => {
   const baseLocale = {
+    nom: 'nom',
     emails: ['mail@domain.net']
   }
 
   const {error} = createSchema.validate(baseLocale)
 
   t.is(error, undefined)
+})
+
+test('not valid payload: no nom', t => {
+  const baseLocale = {
+    emails: ['mail@domain.net']
+  }
+
+  const {error} = createSchema.validate(baseLocale)
+
+  t.true(error.message.includes('"nom" is required'))
 })
 
 test('valid payload: change enableComplement to true', t => {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -20,7 +20,7 @@ const Voie = require('./voie')
 const Numero = require('./numero')
 
 const createSchema = Joi.object().keys({
-  nom: Joi.string().max(200).allow(null),
+  nom: Joi.string().max(200).required(),
   emails: Joi.array().min(1).items(
     Joi.string().email()
   ).required(),
@@ -88,7 +88,7 @@ async function createDemo(payload) {
 }
 
 const updateSchema = Joi.object().keys({
-  nom: Joi.string().max(200).allow(null),
+  nom: Joi.string().max(200),
   status: Joi.string().valid('draft', 'ready-to-publish'),
   emails: Joi.array().min(1).items(
     Joi.string().email()

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -20,7 +20,7 @@ const Voie = require('./voie')
 const Numero = require('./numero')
 
 const createSchema = Joi.object().keys({
-  nom: Joi.string().max(200).required(),
+  nom: Joi.string().min(1).max(200).required(),
   emails: Joi.array().min(1).items(
     Joi.string().email()
   ).required(),
@@ -88,7 +88,7 @@ async function createDemo(payload) {
 }
 
 const updateSchema = Joi.object().keys({
-  nom: Joi.string().max(200),
+  nom: Joi.string().min(1).max(200),
   status: Joi.string().valid('draft', 'ready-to-publish'),
   emails: Joi.array().min(1).items(
     Joi.string().email()

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -59,6 +59,9 @@ test.serial('create a BaseLocale / invalid payload', async t => {
     code: 400,
     message: 'Invalid payload',
     validation: {
+      nom: [
+        '"nom" is required'
+      ],
       emails: [
         '"emails" is required'
       ]
@@ -447,7 +450,7 @@ test.serial('remove a commune from a BaseLocal / without admin token', async t =
 
 test('export as CSV', async t => {
   mockBan54()
-  const {_id} = await BaseLocale.create({emails: ['toto@acme.co']})
+  const {_id} = await BaseLocale.create({nom: 'foo', emails: ['toto@acme.co']})
   await BaseLocale.addCommune(_id, '54084')
   await BaseLocale.populateCommune(_id, '54084')
 
@@ -462,7 +465,7 @@ test('export as CSV', async t => {
 
 test('Export as GeoJSON', async t => {
   mockBan54()
-  const {_id} = await BaseLocale.create({emails: ['toto@acme.co']})
+  const {_id} = await BaseLocale.create({nom: 'foo', emails: ['toto@acme.co']})
   await BaseLocale.addCommune(_id, '54084')
   await BaseLocale.populateCommune(_id, '54084')
 

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -207,13 +207,14 @@ test.serial('modify a BaseLocal / invalid payload', async t => {
   const {status, body} = await request(getApp())
     .put(`/bases-locales/${_id}`)
     .set({Authorization: 'Token coucou'})
-    .send({emails: []})
+    .send({nom: '', emails: []})
 
   t.is(status, 400)
   t.deepEqual(body, {
     code: 400,
     message: 'Invalid payload',
     validation: {
+      nom: ['"nom" is not allowed to be empty'],
       emails: ['"emails" must contain at least 1 items']
     }
   })


### PR DESCRIPTION
- Le champ `nom` est requis lors de la création d'une BAL
- Ajout des tests liées au nouveau modèle 