### PR TITLE
Modifications de la gestion des suffixes

### DIFF
--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -145,6 +145,102 @@ test('update a numero', async t => {
   t.notDeepEqual(numero._created, bal._updated)
 })
 
+test('update a numero / no suffixe', async t => {
+  const idBal = new mongo.ObjectID()
+  const idVoie = new mongo.ObjectID()
+  const _id = new mongo.ObjectID()
+  const referenceDate = new mongo.ObjectID()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    _bal: idBal,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoie,
+    numero: 42,
+    suffixe: 'foo',
+    positions: [],
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+
+  const numero = await Numero.update(_id, {
+    numero: 24,
+    comment: 'Commentaire de numéro 12345 !',
+    positions: [{
+      point: {type: 'Point', coordinates: [0, 0]},
+      source: 'source',
+      type: 'entrée'
+    }]
+  })
+
+  t.is(numero.numero, 24)
+  t.is(numero.suffixe, 'foo')
+  t.is(numero.comment, 'Commentaire de numéro 12345 !')
+  t.is(numero.positions.length, 1)
+  t.is(Object.keys(numero).length, 10)
+
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
+  t.notDeepEqual(numero._created, bal._updated)
+})
+
+test('update a numero / without suffixe', async t => {
+  const idBal = new mongo.ObjectID()
+  const idVoie = new mongo.ObjectID()
+  const _id = new mongo.ObjectID()
+  const referenceDate = new mongo.ObjectID()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal,
+    _updated: referenceDate
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    _bal: idBal,
+    commune: '12345',
+    _updated: referenceDate
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoie,
+    numero: 42,
+    positions: [],
+    suffixe: null,
+    _created: referenceDate,
+    _updated: referenceDate
+  })
+
+  const numero = await Numero.update(_id, {
+    numero: 24,
+    comment: 'Commentaire de numéro 12345 !',
+    positions: [{
+      point: {type: 'Point', coordinates: [0, 0]},
+      source: 'source',
+      type: 'entrée'
+    }]
+  })
+
+  t.is(numero.numero, 24)
+  t.is(numero.suffixe, null)
+  t.is(numero.comment, 'Commentaire de numéro 12345 !')
+  t.is(numero.positions.length, 1)
+  t.is(Object.keys(numero).length, 10)
+
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
+  t.notDeepEqual(numero._created, bal._updated)
+})
+
 test('update a numero / change voie', async t => {
   const idBal = new mongo.ObjectID()
   const idVoieA = new mongo.ObjectID()

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -176,9 +176,6 @@ test('update a numero / no suffixe', async t => {
 
   t.is(numero.numero, 24)
   t.is(numero.suffixe, 'foo')
-
-  const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
-  t.notDeepEqual(numero._created, bal._updated)
 })
 
 test('update a numero / without suffixe', async t => {
@@ -211,9 +208,6 @@ test('update a numero / without suffixe', async t => {
 
   t.is(numero.numero, 24)
   t.is(numero.suffixe, undefined)
-
-  const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
-  t.notDeepEqual(numero._created, bal._updated)
 })
 
 test('update a numero / change voie', async t => {

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -167,27 +167,15 @@ test('update a numero / no suffixe', async t => {
     commune: '12345',
     voie: idVoie,
     numero: 42,
-    suffixe: 'foo',
-    positions: [],
-    _created: referenceDate,
-    _updated: referenceDate
+    suffixe: 'foo'
   })
 
   const numero = await Numero.update(_id, {
-    numero: 24,
-    comment: 'Commentaire de numéro 12345 !',
-    positions: [{
-      point: {type: 'Point', coordinates: [0, 0]},
-      source: 'source',
-      type: 'entrée'
-    }]
+    numero: 24
   })
 
   t.is(numero.numero, 24)
   t.is(numero.suffixe, 'foo')
-  t.is(numero.comment, 'Commentaire de numéro 12345 !')
-  t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 10)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
   t.notDeepEqual(numero._created, bal._updated)
@@ -214,28 +202,15 @@ test('update a numero / without suffixe', async t => {
     _bal: idBal,
     commune: '12345',
     voie: idVoie,
-    numero: 42,
-    positions: [],
-    suffixe: null,
-    _created: referenceDate,
-    _updated: referenceDate
+    numero: 42
   })
 
   const numero = await Numero.update(_id, {
-    numero: 24,
-    comment: 'Commentaire de numéro 12345 !',
-    positions: [{
-      point: {type: 'Point', coordinates: [0, 0]},
-      source: 'source',
-      type: 'entrée'
-    }]
+    numero: 24
   })
 
   t.is(numero.numero, 24)
-  t.is(numero.suffixe, null)
-  t.is(numero.comment, 'Commentaire de numéro 12345 !')
-  t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 10)
+  t.is(numero.suffixe, undefined)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
   t.notDeepEqual(numero._created, bal._updated)

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -91,5 +91,4 @@ test('normalizeSuffixe', t => {
   t.is(normalizeSuffixe('a'), 'a')
   t.is(normalizeSuffixe('A'), 'a')
   t.is(normalizeSuffixe(' A '), 'a')
-  t.is(normalizeSuffixe(null), null)
 })

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -37,7 +37,8 @@ async function create(idVoie, payload) {
   numero.commune = voie.commune
   numero.voie = idVoie
 
-  numero.suffixe = normalizeSuffixe(numero.suffixe)
+  numero.suffixe = numero.suffixe ? normalizeSuffixe(numero.suffixe) : null
+
   numero.positions = numero.positions || []
   numero.comment = numero.comment || null
 
@@ -75,7 +76,10 @@ async function importMany(idBal, rawNumeros, options = {}) {
       numero.commune = n.commune
       numero.voie = n.voie
 
-      numero.suffixe = normalizeSuffixe(n.suffixe)
+      if (n.suffixe) {
+        numero.suffixe = normalizeSuffixe(n.suffixe)
+      }
+
       numero.positions = n.positions || []
 
       if (n._updated && n._created) {
@@ -118,7 +122,9 @@ async function update(id, payload) {
     }
   }
 
-  numeroChanges.suffixe = normalizeSuffixe(numeroChanges.suffixe)
+  if (numeroChanges.suffixe) {
+    numeroChanges.suffixe = normalizeSuffixe(numeroChanges.suffixe)
+  }
 
   mongo.decorateModification(numeroChanges)
 
@@ -182,7 +188,7 @@ function expandModel(numero) {
 }
 
 function normalizeSuffixe(suffixe) {
-  return suffixe ? suffixe.toLowerCase().trim() : null
+  return suffixe.toLowerCase().trim()
 }
 
 module.exports = {


### PR DESCRIPTION
Le traitement appliquer à la chaine de caractère du suffixe avait pour effet d'attribuer une valeur par défaut (`null`) à ce champ même quand celui-ci n'était pas présent dans le `payload`. Ce qui avait comme effet de bord d'écraser le `suffixe` si celui-ci existait.