### PR TITLE
Amélioration de la méthode fetchByToponyme et de la route y faisant référence

### DIFF
--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -3,6 +3,7 @@ const {getFilteredPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
 const position = require('./position')
+const {uniqBy} = require('lodash')
 
 const createSchema = Joi.object().keys({
   numero: Joi.number().min(0).max(9999).integer().required(),
@@ -187,17 +188,21 @@ async function fetchAll(idVoie) {
 
 async function fetchByToponyme(id) {
   const numerosWithToponyme = await mongo.db.collection('numeros').find({toponyme: id}).toArray()
-  const voies = await mongo.db.collection('voies').find({_id: {$in: numerosWithToponyme.map(r => r.voie)}}).toArray()
+  const voiesIds = uniqBy(numerosWithToponyme.map(n => n.voie), voieId => voieId.toString())
+  const voies = await mongo.db.collection('voies').find({_id: {$in: voiesIds}}).toArray()
 
-  for (const numero of numerosWithToponyme) {
-    const {_id, nom} = voies.find(({_id}) => _id.toHexString() === numero.voie.toHexString())
-    numero.voie = {
-      _id,
-      nom
+  const numerosToponymeWithNomVoie = numerosWithToponyme.map(n => {
+    const {_id, nom} = voies.find(({_id}) => _id.toHexString() === n.voie.toHexString())
+    return {
+      ...n,
+      voie: {
+        _id,
+        nom
+      }
     }
-  }
+  })
 
-  return numerosWithToponyme
+  return numerosToponymeWithNomVoie
 }
 
 async function remove(id) {

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -196,6 +196,10 @@ async function fetchByToponyme(id) {
         {$project: {_id: 1, nom: 1}}
       ],
       as: 'voie'
+    }},
+    {$unwind: {
+      path: '$voie',
+      preserveNullAndEmptyArrays: true
     }}
   ]).toArray()
 }

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -186,22 +186,18 @@ async function fetchAll(idVoie) {
 }
 
 async function fetchByToponyme(id) {
-  return mongo.db.collection('numeros').aggregate([
-    {$match: {toponyme: id}},
-    {$lookup: {
-      from: 'voies',
-      let: {idVoie: '$voie'},
-      pipeline: [
-        {$match: {$expr: {$eq: ['$_id', '$$idVoie']}}},
-        {$project: {_id: 1, nom: 1}}
-      ],
-      as: 'voie'
-    }},
-    {$unwind: {
-      path: '$voie',
-      preserveNullAndEmptyArrays: true
-    }}
-  ]).toArray()
+  const numerosWithToponyme = await mongo.db.collection('numeros').find({toponyme: id}).toArray()
+  const voies = await mongo.db.collection('voies').find({_id: {$in: numerosWithToponyme.map(r => r.voie)}}).toArray()
+
+  for (const numero of numerosWithToponyme) {
+    const {_id, nom} = voies.find(({_id}) => _id.toHexString() === numero.voie.toHexString())
+    numero.voie = {
+      _id,
+      nom
+    }
+  }
+
+  return numerosWithToponyme
 }
 
 async function remove(id) {

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -210,20 +210,26 @@ test.serial('get all numeros from a toponyme', async t => {
     nom: 'foo',
     emails: ['me@domain.tld'],
     communes: ['12345'],
-    token: 'coucou'
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
   })
   await mongo.db.collection('voies').insertOne({
     _id: _idVoie,
     _bal: _idBal,
     commune: '12345',
-    nom: 'voie'
+    nom: 'voie',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
   })
   await mongo.db.collection('toponymes').insertOne({
     _id: _idToponyme,
     _bal: _idBal,
     commune: '12345',
     nom: 'toponyme',
-    positions: []
+    positions: [],
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
   })
   await mongo.db.collection('numeros').insertOne({
     _id: _idNumeroA,
@@ -231,14 +237,21 @@ test.serial('get all numeros from a toponyme', async t => {
     commune: '12345',
     voie: _idVoie,
     numero: 42,
-    toponyme: _idToponyme
+    positions: [],
+    comment: null,
+    suffixe: 'bis',
+    toponyme: _idToponyme,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
   })
   await mongo.db.collection('numeros').insertOne({
     _id: _idNumeroB,
     _bal: _idBal,
     commune: '12345',
     voie: _idVoie,
-    numero: 24
+    numero: 24,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
   })
 
   const {status, body} = await request(getApp())
@@ -246,6 +259,22 @@ test.serial('get all numeros from a toponyme', async t => {
 
   t.is(status, 200)
   t.is(body.length, 1)
+  t.deepEqual(omit(body[0], GENERATED_VARS), {
+    _bal: _idBal.toHexString(),
+    commune: '12345',
+    numero: 42,
+    comment: null,
+    numeroComplet: '42bis',
+    positions: [],
+    suffixe: 'bis',
+    toponyme: _idToponyme.toHexString(),
+    voie: {
+      _id: _idVoie.toHexString(),
+      nom: 'voie'
+    }
+  })
+  t.true(KEYS.every(k => k in body[0]))
+  t.is(Object.keys(body[0]).length, KEYS.length)
 })
 
 test.serial('get all numeros from a toponyme / invalid toponyme', async t => {

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -260,7 +260,7 @@ app.route('/toponymes/:toponymeId')
 app.route('/toponymes/:toponymeId/numeros')
   .get(w(async (req, res) => {
     const numeros = await Numero.fetchByToponyme(req.toponyme._id)
-    res.send(numeros)
+    res.send(numeros.map(n => Numero.expandModel(n)))
   }))
 
 app.use('/stats', stats)


### PR DESCRIPTION
- la route `/toponymes/:toponymeId/numeros` renvoie la liste des numéros avec un objet voie au lieu d'un "array"
- renvoie également un format étendu des numéros avec l'ajout de `Numero.expandModel(numero)`
- mise à jour des tests liés à la méthode

*edit : 04/05*

- ### ~~liée à la [PR #329](https://github.com/etalab/editeur-bal/pull/329) de `editeur-bal`~~
- `$lookup` est remplacé par deux appels à la base de données mongo
- ### liée à la [PR #333](https://github.com/etalab/editeur-bal/pull/333) de `editeur-bal`

*edit : 05/05*
- `for of` remplacé par `map`
- utilisation d'un identifiant de voie unique