### PR TITLE
Ajout des parcelles dans les numéros

### DIFF
--- a/lib/export/__tests__/csv-bal.js
+++ b/lib/export/__tests__/csv-bal.js
@@ -31,7 +31,8 @@ test('createRow', t => {
         type: 'Point',
         coordinates: [5.835188, 49.326038]
       }
-    }
+    },
+    parcelles: ['12345000AA0001', '12345000AA0002']
   }), {
     cle_interop: '54084_xxxx_00012_bis',
     uid_adresse: '',
@@ -45,6 +46,7 @@ test('createRow', t => {
     lat: '49.326038',
     x: '906109.41',
     y: '6917751.73',
+    cad_parcelles: '12345000AA0001|12345000AA0002',
     source: 'Mairie',
     date_der_maj: '2019-01-01'
   })
@@ -85,6 +87,7 @@ test('exportAsCsv', async t => {
         coordinates: [5.83315, 49.324433]
       }
     }],
+    parcelles: ['12345000AA0001', '12345000AA0002'],
     _updated: new Date('2019-01-05')
   }
 
@@ -95,6 +98,7 @@ test('exportAsCsv', async t => {
       numero: 1,
       suffixe: 'bis',
       positions: [],
+      parcelles: [],
       _updated: new Date('2019-02-01')
     },
     {
@@ -110,15 +114,16 @@ test('exportAsCsv', async t => {
           coordinates: [5.83315, 49.324433]
         }
       }],
+      parcelles: ['12345000AA0001', '12345000AA0002'],
       _updated: new Date('2019-02-05')
     }
   ]
 
   const csv = await exportAsCsv({voies: [voie1, voie2], toponymes: [hameau, lieuDit], numeros})
-  const expected = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;position;long;lat;x;y;source;date_der_maj
-54084_6789_00001_bis;;allée des acacias;;1;bis;Mont-Bonvillers;;;;;;;2019-02-01
-54084_6789_00006;;allée des acacias;La Varenne;6;;Mont-Bonvillers;entrée;5.83315;49.324433;905967.72;6917567.98;Mairie;2019-02-05
-54084_xxxx_99999;;La Varenne;;99999;;Mont-Bonvillers;;;;;;;2019-01-05
-54084_xxxx_99999;;Le Moulin;;99999;;Mont-Bonvillers;segment;5.83315;49.324433;905967.72;6917567.98;Mairie;2019-01-05`.replace(/\n/g, '\r\n') + '\r\n'
+  const expected = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
+54084_6789_00001_bis;;allée des acacias;;1;bis;Mont-Bonvillers;;;;;;;;2019-02-01
+54084_6789_00006;;allée des acacias;La Varenne;6;;Mont-Bonvillers;entrée;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-02-05
+54084_xxxx_99999;;La Varenne;;99999;;Mont-Bonvillers;;;;;;;;2019-01-05
+54084_xxxx_99999;;Le Moulin;;99999;;Mont-Bonvillers;segment;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-01-05`.replace(/\n/g, '\r\n') + '\r\n'
   t.is(csv, expected)
 })

--- a/lib/export/__tests__/geojson.js
+++ b/lib/export/__tests__/geojson.js
@@ -17,7 +17,8 @@ test('numeroVoieToAdresseFeature', t => {
         type: 'entrée',
         point: {type: 'Point', coordinates: [4, 5]}
       }
-    ]
+    ],
+    parcelles: ['12345666AA', '12345666BB']
   }
   const voie = {
     _bal: 'bal',
@@ -39,7 +40,8 @@ test('numeroVoieToAdresseFeature', t => {
       nomToponyme: null,
       numero: 12,
       suffixe: 'ter',
-      typePosition: 'entrée'
+      typePosition: 'entrée',
+      parcelles: ['12345666AA', '12345666BB']
     }
   })
 })
@@ -60,7 +62,8 @@ test('numeroVoieToAdresseFeature with toponyme', t => {
         type: 'entrée',
         point: {type: 'Point', coordinates: [4, 5]}
       }
-    ]
+    ],
+    parcelles: ['12345666AA', '12345666BB']
   }
   const voie = {
     _bal: 'bal',
@@ -86,7 +89,8 @@ test('numeroVoieToAdresseFeature with toponyme', t => {
       nomToponyme: 'le moulin',
       numero: 12,
       suffixe: 'ter',
-      typePosition: 'entrée'
+      typePosition: 'entrée',
+      parcelles: ['12345666AA', '12345666BB']
     }
   })
 })

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -88,7 +88,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
           _updated: n._updated,
           nomVoie: v.nom,
           nomToponyme: n.toponyme ? n.toponyme.nom : null,
-          parcelles: n.parcelles ? n.parcelles : null,
+          parcelles: n.parcelles,
           position: p
         })
       })
@@ -101,7 +101,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
         _updated: n._updated,
         nomVoie: v.nom,
         nomToponyme: n.toponyme ? n.toponyme.nom : null,
-        parcelles: n.parcelles ? n.parcelles : null
+        parcelles: n.parcelles
       })
     }
   })
@@ -115,7 +115,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
           numero: 99999,
           _updated: t._updated,
           nomVoie: t.nom,
-          parcelles: t.parcelles ? t.parcelles : null,
+          parcelles: t.parcelles,
           position: p
         })
       })
@@ -126,7 +126,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
         numero: 99999,
         _updated: t._updated,
         nomVoie: t.nom,
-        parcelles: t.parcelles ? t.parcelles : null
+        parcelles: t.parcelles
       })
     }
   })

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -40,7 +40,7 @@ function createRow(obj) {
     lat: '',
     x: '',
     y: '',
-    cad_parcelles: obj.parcelles?.join('|') || '',
+    cad_parcelles: obj.parcelles ? obj.parcelles.join('|') : '',
     source: obj.source || '',
     date_der_maj: obj._updated ? obj._updated.toISOString().slice(0, 10) : ''
   }

--- a/lib/export/csv-bal.js
+++ b/lib/export/csv-bal.js
@@ -40,6 +40,7 @@ function createRow(obj) {
     lat: '',
     x: '',
     y: '',
+    cad_parcelles: obj.parcelles?.join('|') || '',
     source: obj.source || '',
     date_der_maj: obj._updated ? obj._updated.toISOString().slice(0, 10) : ''
   }
@@ -87,6 +88,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
           _updated: n._updated,
           nomVoie: v.nom,
           nomToponyme: n.toponyme ? n.toponyme.nom : null,
+          parcelles: n.parcelles ? n.parcelles : null,
           position: p
         })
       })
@@ -98,7 +100,8 @@ async function exportAsCsv({voies, toponymes, numeros}) {
         suffixe: n.suffixe,
         _updated: n._updated,
         nomVoie: v.nom,
-        nomToponyme: n.toponyme ? n.toponyme.nom : null
+        nomToponyme: n.toponyme ? n.toponyme.nom : null,
+        parcelles: n.parcelles ? n.parcelles : null
       })
     }
   })
@@ -112,6 +115,7 @@ async function exportAsCsv({voies, toponymes, numeros}) {
           numero: 99999,
           _updated: t._updated,
           nomVoie: t.nom,
+          parcelles: t.parcelles ? t.parcelles : null,
           position: p
         })
       })
@@ -121,7 +125,8 @@ async function exportAsCsv({voies, toponymes, numeros}) {
         codeVoie: t.code || 'xxxx',
         numero: 99999,
         _updated: t._updated,
-        nomVoie: t.nom
+        nomVoie: t.nom,
+        parcelles: t.parcelles ? t.parcelles : null
       })
     }
   })

--- a/lib/export/geojson.js
+++ b/lib/export/geojson.js
@@ -28,7 +28,8 @@ function numeroVoieToAdresseFeature(n, v, t) {
     nomToponyme,
     numero: n.numero,
     suffixe: n.suffixe,
-    typePosition: position.type
+    typePosition: position.type,
+    parcelles: n.parcelles
   }
 
   return {

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -353,6 +353,8 @@ test('Get all assigned parcelles', async t => {
 
   const parcelles = await getAssignedParcelles(_id.toString(), '54084')
 
-  t.is(parcelles.length, 4)
-  t.deepEqual(parcelles, ['12345000AA0002', '12345000AA0001', '12345000AA0003', '12345000AA0004'])
+  t.is(parcelles.length, 4);
+  ['12345000AA0001', '12345000AA0002', '12345000AA0003', '12345000AA0004'].forEach(p => {
+    t.true(parcelles.includes(p))
+  })
 })

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -2,6 +2,7 @@ const test = require('ava')
 const {MongoMemoryServer} = require('mongodb-memory-server')
 const mongo = require('../../util/mongo')
 const BaseLocale = require('../base-locale')
+const {getAssignedParcelles} = require('../base-locale')
 const {mockBan54} = require('../../populate/__mocks__/ban')
 
 const mongod = new MongoMemoryServer()
@@ -333,4 +334,24 @@ test('find Bases Locales by codes communes / no BAL found', async t => {
   const basesLocales = await BaseLocale.fetchByCommunes(['77123'])
 
   t.is(basesLocales.length, 0)
+})
+
+test('Get all assigned parcelles', async t => {
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    token: 'coucou',
+    communes: ['54084']
+  })
+
+  await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 1, commune: '54084', parcelles: ['12345000AA0002']})
+  await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 2, commune: '54084', parcelles: ['12345000AA0001', '12345000AA0003']})
+  await mongo.db.collection('numeros').insertOne({_bal: _id, numero: 3, commune: '54084'})
+  await mongo.db.collection('toponymes').insertOne({_bal: _id, commune: '54084'})
+  await mongo.db.collection('toponymes').insertOne({_bal: _id, commune: '54084', parcelles: ['12345000AA0003']})
+  await mongo.db.collection('toponymes').insertOne({_bal: _id, commune: '54084', parcelles: ['12345000AA0004', '12345000AA0001']})
+
+  const parcelles = await getAssignedParcelles(_id.toString(), '54084')
+
+  t.is(parcelles.length, 4)
 })

--- a/lib/models/__tests__/base-locale.mongo.js
+++ b/lib/models/__tests__/base-locale.mongo.js
@@ -354,4 +354,5 @@ test('Get all assigned parcelles', async t => {
   const parcelles = await getAssignedParcelles(_id.toString(), '54084')
 
   t.is(parcelles.length, 4)
+  t.deepEqual(parcelles, ['12345000AA0002', '12345000AA0001', '12345000AA0003', '12345000AA0004'])
 })

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -92,21 +92,19 @@ test('create a numero with toponyme', async t => {
 
 test('create a numero with parcelles', async t => {
   const _id = new mongo.ObjectID()
-  const parcelles = ['12345000AA0001']
   await mongo.db.collection('voies').insertOne({_id})
   const numero = await Numero.create(
     _id,
-    {numero: 42, parcelles}
+    {numero: 42, parcelles: ['12345000AA0001', '12345000AA0002']}
   )
 
-  t.deepEqual(numero.parcelles, parcelles)
+  t.deepEqual(numero.parcelles, ['12345000AA0001', '12345000AA0002'])
 })
 
 test('create a numero with parcelles / lowercase', async t => {
   const _id = new mongo.ObjectID()
-  const parcelles = ['12345000aa0001']
   await mongo.db.collection('voies').insertOne({_id})
-  const error = await t.throwsAsync(() => Numero.create(_id, {numero: 42, parcelles}))
+  const error = await t.throwsAsync(() => Numero.create(_id, {numero: 42, parcelles: ['12345000aa0001']}))
 
   t.deepEqual(error.validation, {
     parcelles: ['"parcelles[0]" with value "12345000aa0001" fails to match the required pattern: /^[A-Z\\d]+$/']

--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -35,7 +35,7 @@ test('create a numero', async t => {
     positions: []
   })
 
-  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'comment', 'toponyme', 'positions']
+  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'comment', 'toponyme', 'positions', 'parcelles']
   t.true(keys.every(k => k in numero))
   t.is(Object.keys(numero).length, keys.length)
 
@@ -60,7 +60,7 @@ test('create a numero / minimal', async t => {
   await mongo.db.collection('voies').insertOne({_id})
   const numero = await Numero.create(_id, {numero: 42})
 
-  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'positions', 'comment', 'toponyme']
+  const keys = ['_id', '_bal', 'commune', '_updated', '_created', 'voie', 'numero', 'suffixe', 'positions', 'comment', 'toponyme', 'parcelles']
   t.true(keys.every(k => k in numero))
   t.is(Object.keys(numero).length, keys.length)
 })
@@ -88,6 +88,44 @@ test('create a numero with toponyme', async t => {
   const numero = await Numero.create(_idVoie, {numero: 42, toponyme: _idToponyme.toString()})
 
   t.deepEqual(numero.toponyme, _idToponyme)
+})
+
+test('create a numero with parcelles', async t => {
+  const _id = new mongo.ObjectID()
+  const parcelles = ['12345000AA0001']
+  await mongo.db.collection('voies').insertOne({_id})
+  const numero = await Numero.create(
+    _id,
+    {numero: 42, parcelles}
+  )
+
+  t.deepEqual(numero.parcelles, parcelles)
+})
+
+test('create a numero with parcelles / lowercase', async t => {
+  const _id = new mongo.ObjectID()
+  const parcelles = ['12345000aa0001']
+  await mongo.db.collection('voies').insertOne({_id})
+  const error = await t.throwsAsync(() => Numero.create(_id, {numero: 42, parcelles}))
+
+  t.deepEqual(error.validation, {
+    parcelles: ['"parcelles[0]" with value "12345000aa0001" fails to match the required pattern: /^[A-Z\\d]+$/']
+  })
+
+  t.is(error.message, 'Invalid payload')
+})
+
+test('create a numero with parcelles / less than 14 characters', async t => {
+  const _id = new mongo.ObjectID()
+  const parcelles = ['12345000AA']
+  await mongo.db.collection('voies').insertOne({_id})
+  const error = await t.throwsAsync(() => Numero.create(_id, {numero: 42, parcelles}))
+
+  t.deepEqual(error.validation, {
+    parcelles: ['"parcelles[0]" length must be 14 characters long']
+  })
+
+  t.is(error.message, 'Invalid payload')
 })
 
 test('create a numero / voie do not exists', t => {
@@ -156,7 +194,7 @@ test('update a numero', async t => {
   t.is(numero.suffixe, 'bar')
   t.is(numero.comment, 'Commentaire de numéro 123 !')
   t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 10)
+  t.is(Object.keys(numero).length, 11)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
   t.notDeepEqual(numero._created, bal._updated)
@@ -277,7 +315,7 @@ test('update a numero / change voie', async t => {
   t.is(numero.suffixe, 'bar')
   t.is(numero.comment, 'Commentaire de numéro 123 !')
   t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 10)
+  t.is(Object.keys(numero).length, 11)
 
   t.deepEqual(numero.voie, idVoieB)
 })
@@ -329,7 +367,7 @@ test('update a numero / add toponyme', async t => {
 
   t.is(numero.numero, 24)
   t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 9)
+  t.is(Object.keys(numero).length, 10)
   t.deepEqual(numero.toponyme, idToponyme)
 })
 
@@ -387,7 +425,7 @@ test('update a numero / change toponyme', async t => {
 
   t.is(numero.numero, 42)
   t.is(numero.positions.length, 1)
-  t.is(Object.keys(numero).length, 9)
+  t.is(Object.keys(numero).length, 10)
   t.deepEqual(numero.toponyme, idToponymeB)
 })
 

--- a/lib/models/__tests__/numero.schema.js
+++ b/lib/models/__tests__/numero.schema.js
@@ -16,7 +16,8 @@ test('valid payload', t => {
   const numero = {
     numero: 42,
     suffixe: 'bis',
-    positions: []
+    positions: [],
+    parcelles: []
   }
 
   const {error} = createSchema.validate(numero)
@@ -76,6 +77,17 @@ test('not valid payload: invalid toponyme', t => {
   t.truthy(error)
 })
 
+test('not valid payload: invalid parcelle', t => {
+  const numero = {
+    numero: 42,
+    parcelles: ['invalid']
+  }
+
+  const {error} = createSchema.validate(numero)
+
+  t.truthy(error)
+})
+
 test('valid payload update', t => {
   const _idVoie = new mongo.ObjectID()
 
@@ -84,7 +96,8 @@ test('valid payload update', t => {
     voie: _idVoie.toString(),
     suffixe: 'bis',
     comment: 'Hello world',
-    positions: []
+    positions: [],
+    parcelles: []
   }
 
   const {error} = updateSchema.validate(numero)
@@ -115,6 +128,22 @@ test('invalid payload update / invalid toponyme', t => {
     comment: 'Hello world',
     positions: [],
     toponyme: 'invalid'
+  }
+
+  const {error} = updateSchema.validate(numero)
+  t.truthy(error)
+})
+
+test('invalid payload update / invalid parcelles', t => {
+  const _idVoie = new mongo.ObjectID()
+
+  const numero = {
+    numero: 42,
+    voie: _idVoie.toString(),
+    suffixe: 'bis',
+    comment: 'Hello world',
+    positions: [],
+    parcelles: ['invalid']
   }
 
   const {error} = updateSchema.validate(numero)

--- a/lib/models/__tests__/toponyme.mongo.js
+++ b/lib/models/__tests__/toponyme.mongo.js
@@ -151,6 +151,63 @@ test('update a Toponyme', async t => {
   t.deepEqual(bal._updated, toponyme._updated)
 })
 
+test('update a Toponyme with parcelles', async t => {
+  const _idBal = new mongo.ObjectID()
+  const _id = new mongo.ObjectID()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: new Date('2021-01-01')
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id,
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '12345',
+    positions: [{
+      point: {type: 'Point', coordinates: [0, 0]},
+      source: 'source',
+      type: 'entrée'
+    }],
+    parcelles: []
+  })
+
+  const toponyme = await Toponyme.update(_id, {
+    nom: 'bar',
+    parcelles: ['64284000BI0459', '64284000BI0450']
+  })
+
+  t.is(toponyme.nom, 'bar')
+  t.is(toponyme.parcelles.length, 2)
+
+  const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
+  t.deepEqual(bal._updated, toponyme._updated)
+})
+
+test('update a Toponyme with wrong parcelles', async t => {
+  const _idBal = new mongo.ObjectID()
+  const _id = new mongo.ObjectID()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    _updated: new Date('2021-01-01')
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id,
+    _bal: _idBal,
+    nom: 'foo',
+    commune: '12345',
+    positions: [{
+      point: {type: 'Point', coordinates: [0, 0]},
+      source: 'source',
+      type: 'entrée'
+    }],
+    parcelles: []
+  })
+
+  return t.throwsAsync(() => Toponyme.update(_id, {parcelles: ['AA284000BI0', 'ZZ284000BI']}, {message: 'Invalid payload'}))
+})
+
 test('create a Toponyme / base locale do not exists', t => {
   const _id = new mongo.ObjectID()
   return t.throwsAsync(Toponyme.create(_id, '12345', {nom: 'toponyme'}, {message: 'Base locale not found'}))

--- a/lib/models/__tests__/toponyme.mongo.js
+++ b/lib/models/__tests__/toponyme.mongo.js
@@ -25,7 +25,7 @@ test('create a Toponyme', async t => {
 
   const toponyme = await Toponyme.create(_id, '12345', {nom: 'foo'})
 
-  const keys = ['_id', '_bal', 'nom', 'positions', 'commune', '_created', '_updated']
+  const keys = ['_id', '_bal', 'nom', 'positions', 'parcelles', 'commune', '_created', '_updated']
   t.true(keys.every(k => k in toponyme))
   t.is(Object.keys(toponyme).length, keys.length)
 
@@ -58,6 +58,7 @@ test('importMany', async t => {
     nom: 'foo',
     commune: '12345',
     positions: [],
+    parcelles: [],
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-05')
   }
@@ -65,7 +66,8 @@ test('importMany', async t => {
     _bal: _idBal,
     nom: 'bar',
     commune: '23456',
-    positions: []
+    positions: [],
+    parcelles: []
   }
 
   Toponyme.importMany(_idBal, [toponyme1, toponyme2], {validate: false})
@@ -74,14 +76,14 @@ test('importMany', async t => {
 
   const v1 = toponymes.find(v => v.nom === 'foo')
   t.deepEqual(
-    pick(v1, 'nom', 'commune', 'positions', '_updated', '_created'),
-    pick(toponyme1, 'nom', 'commune', 'positions', '_updated', '_created')
+    pick(v1, 'nom', 'commune', 'positions', 'parcelles', '_updated', '_created'),
+    pick(toponyme1, 'nom', 'commune', 'positions', 'parcelles', '_updated', '_created')
   )
 
   const v2 = toponymes.find(v => v.nom === 'bar')
   t.deepEqual(
-    pick(v2, 'nom', 'commune', 'positions'),
-    pick(toponyme2, 'nom', 'commune', 'positions')
+    pick(v2, 'nom', 'commune', 'positions', 'parcelles'),
+    pick(toponyme2, 'nom', 'commune', 'positions', 'parcelles')
   )
 })
 
@@ -129,7 +131,8 @@ test('update a Toponyme', async t => {
     _id,
     _bal: _idBal,
     nom: 'foo',
-    commune: '12345'
+    commune: '12345',
+    parcelles: ['64284000BI0459', '64284000BI0450']
   })
 
   const toponyme = await Toponyme.update(_id, {
@@ -182,6 +185,7 @@ test('remove a Toponyme', async t => {
     numero: 42,
     suffixe: 'foo',
     positions: [],
+    parcelles: [],
     _created: referenceDate,
     _updated: referenceDate
   })

--- a/lib/models/__tests__/toponyme.mongo.js
+++ b/lib/models/__tests__/toponyme.mongo.js
@@ -33,7 +33,7 @@ test('create a Toponyme', async t => {
   t.deepEqual(toponyme._created, bal._updated)
 })
 
-test('create a Toponyme / with positions', async t => {
+test('create a Toponyme / with positions & parcelles', async t => {
   const _id = new mongo.ObjectID()
 
   await mongo.db.collection('bases_locales').insertOne({_id})
@@ -45,10 +45,12 @@ test('create a Toponyme / with positions', async t => {
   }
   const toponyme = await Toponyme.create(_id, '12345', {
     nom: 'foo',
+    parcelles: ['64284000BI0459', '64284000BI0450'],
     positions: [position]
   })
 
   t.deepEqual(toponyme.positions, [position])
+  t.deepEqual(toponyme.parcelles, ['64284000BI0459', '64284000BI0450'])
 })
 
 test('importMany', async t => {
@@ -132,11 +134,12 @@ test('update a Toponyme', async t => {
     _bal: _idBal,
     nom: 'foo',
     commune: '12345',
-    parcelles: ['64284000BI0459', '64284000BI0450']
+    parcelles: []
   })
 
   const toponyme = await Toponyme.update(_id, {
     nom: 'bar',
+    parcelles: ['64284000BI0459', '64284000BI0450'],
     positions: [{
       point: {type: 'Point', coordinates: [0, 0]},
       source: 'source',
@@ -146,45 +149,13 @@ test('update a Toponyme', async t => {
 
   t.is(toponyme.nom, 'bar')
   t.is(toponyme.positions.length, 1)
-
-  const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
-  t.deepEqual(bal._updated, toponyme._updated)
-})
-
-test('update a Toponyme with parcelles', async t => {
-  const _idBal = new mongo.ObjectID()
-  const _id = new mongo.ObjectID()
-
-  await mongo.db.collection('bases_locales').insertOne({
-    _id: _idBal,
-    _updated: new Date('2021-01-01')
-  })
-  await mongo.db.collection('toponymes').insertOne({
-    _id,
-    _bal: _idBal,
-    nom: 'foo',
-    commune: '12345',
-    positions: [{
-      point: {type: 'Point', coordinates: [0, 0]},
-      source: 'source',
-      type: 'entrée'
-    }],
-    parcelles: []
-  })
-
-  const toponyme = await Toponyme.update(_id, {
-    nom: 'bar',
-    parcelles: ['64284000BI0459', '64284000BI0450']
-  })
-
-  t.is(toponyme.nom, 'bar')
   t.is(toponyme.parcelles.length, 2)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: _idBal})
   t.deepEqual(bal._updated, toponyme._updated)
 })
 
-test('update a Toponyme with wrong parcelles', async t => {
+test('update a Toponyme with invalid parcelles', async t => {
   const _idBal = new mongo.ObjectID()
   const _id = new mongo.ObjectID()
 

--- a/lib/models/__tests__/toponyme.schema.js
+++ b/lib/models/__tests__/toponyme.schema.js
@@ -18,7 +18,8 @@ test('valid payload: with positions', t => {
         type: 'entrée',
         source: 'ban'
       }
-    ]
+    ],
+    parcelles: ['64284000BI0459', '64284000BI0450']
   }
 
   const {error} = createSchema.validate(toponyme)
@@ -51,7 +52,8 @@ test('not valid payload: nom missing', t => {
 test('not valid payload: position invalid in positions', t => {
   const toponyme = {
     nom: 'toponyme',
-    positions: [{}]
+    positions: [{}],
+    parcelles: []
   }
 
   const {error} = createSchema.validate(toponyme)

--- a/lib/models/__tests__/toponyme.schema.js
+++ b/lib/models/__tests__/toponyme.schema.js
@@ -60,3 +60,15 @@ test('not valid payload: position invalid in positions', t => {
 
   t.truthy(error)
 })
+
+test('not valid payload: invalid parcelles', t => {
+  const toponyme = {
+    nom: 'toponyme',
+    positions: [],
+    parcelles: ['PARCELLE', 'CC55DATA']
+  }
+
+  const {error} = createSchema.validate(toponyme)
+
+  t.truthy(error)
+})

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -1,7 +1,7 @@
 const communes = require('@etalab/decoupage-administratif/data/communes.json')
 const Joi = require('joi')
 const got = require('got')
-const {omit, uniqBy, difference, uniq, flatten} = require('lodash')
+const {omit, uniqBy, difference, uniq} = require('lodash')
 const {generateBase62String} = require('../util/base62')
 const {validPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
@@ -390,15 +390,15 @@ async function basesLocalesRecovery(userEmail) {
 }
 
 async function getAssignedParcelles(balId, codeCommune) {
-  const numeroWithParcelles = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(balId), commune: codeCommune}).toArray()
-  const toponymesWithParcelles = await mongo.db.collection('toponymes').find({_bal: mongo.parseObjectID(balId), commune: codeCommune}).toArray()
+  const numeroWithParcelles = await mongo.db.collection('numeros').distinct('parcelles', {_bal: mongo.parseObjectID(balId), commune: codeCommune})
+  const toponymesWithParcelles = await mongo.db.collection('toponymes').distinct('parcelles', {_bal: mongo.parseObjectID(balId), commune: codeCommune})
 
   const parcelles = [
-    ...numeroWithParcelles.map(({parcelles}) => parcelles || []),
-    ...toponymesWithParcelles.map(({parcelles}) => parcelles || [])
+    ...numeroWithParcelles,
+    ...toponymesWithParcelles
   ]
 
-  return uniq(flatten(parcelles))
+  return uniq(parcelles)
 }
 
 module.exports = {

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -389,7 +389,7 @@ async function basesLocalesRecovery(userEmail) {
   }
 }
 
-async function getUniqParcelles(balId, codeCommune) {
+async function getAssignedParcelles(balId, codeCommune) {
   const numeroWithParcelles = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(balId), commune: codeCommune, 'parcelles.1': {$exists: true}}).toArray()
   const toponymesWithParcelles = await mongo.db.collection('toponymes').find({_bal: mongo.parseObjectID(balId), commune: codeCommune, 'parcelles.1': {$exists: true}}).toArray()
 
@@ -426,5 +426,5 @@ module.exports = {
   filterSensitiveFields,
   computeStats,
   basesLocalesRecovery,
-  getUniqParcelles
+  getAssignedParcelles
 }

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -390,12 +390,12 @@ async function basesLocalesRecovery(userEmail) {
 }
 
 async function getAssignedParcelles(balId, codeCommune) {
-  const numeroWithParcelles = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(balId), commune: codeCommune, 'parcelles.1': {$exists: true}}).toArray()
-  const toponymesWithParcelles = await mongo.db.collection('toponymes').find({_bal: mongo.parseObjectID(balId), commune: codeCommune, 'parcelles.1': {$exists: true}}).toArray()
+  const numeroWithParcelles = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(balId), commune: codeCommune}).toArray()
+  const toponymesWithParcelles = await mongo.db.collection('toponymes').find({_bal: mongo.parseObjectID(balId), commune: codeCommune}).toArray()
 
   const parcelles = [
-    ...numeroWithParcelles.map(({parcelles}) => parcelles),
-    ...toponymesWithParcelles.map(({parcelles}) => parcelles)
+    ...numeroWithParcelles.map(({parcelles}) => parcelles || []),
+    ...toponymesWithParcelles.map(({parcelles}) => parcelles || [])
   ]
 
   return uniq(flatten(parcelles))

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -1,7 +1,7 @@
 const communes = require('@etalab/decoupage-administratif/data/communes.json')
 const Joi = require('joi')
 const got = require('got')
-const {omit, uniqBy, difference} = require('lodash')
+const {omit, uniqBy, difference, uniq, flatten} = require('lodash')
 const {generateBase62String} = require('../util/base62')
 const {validPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
@@ -389,6 +389,18 @@ async function basesLocalesRecovery(userEmail) {
   }
 }
 
+async function getUniqParcelles(balId, codeCommune) {
+  const numeroWithParcelles = await mongo.db.collection('numeros').find({_bal: mongo.parseObjectID(balId), commune: codeCommune, 'parcelles.1': {$exists: true}}).toArray()
+  const toponymesWithParcelles = await mongo.db.collection('toponymes').find({_bal: mongo.parseObjectID(balId), commune: codeCommune, 'parcelles.1': {$exists: true}}).toArray()
+
+  const parcelles = [
+    ...numeroWithParcelles.map(({parcelles}) => parcelles),
+    ...toponymesWithParcelles.map(({parcelles}) => parcelles)
+  ]
+
+  return uniq(flatten(parcelles))
+}
+
 module.exports = {
   create,
   createSchema,
@@ -413,5 +425,6 @@ module.exports = {
   importFile,
   filterSensitiveFields,
   computeStats,
-  basesLocalesRecovery
+  basesLocalesRecovery,
+  getUniqParcelles
 }

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -12,7 +12,10 @@ const createSchema = Joi.object().keys({
   positions: Joi.array().items(
     position.createSchema
   ),
-  toponyme: Joi.string().custom(validObjectID).allow(null)
+  toponyme: Joi.string().custom(validObjectID).allow(null),
+  parcelles: Joi.array().items(
+    Joi.string().regex(/^[A-Z\d]+$/).length(14)
+  ).default([])
 })
 
 function validObjectID(id) {
@@ -43,6 +46,7 @@ async function create(idVoie, payload) {
 
   numero.positions = numero.positions || []
   numero.comment = numero.comment || null
+  numero.parcelles = numero.parcelles || []
 
   if (numero.toponyme) {
     const toponyme = await mongo.db.collection('toponymes').findOne({
@@ -124,7 +128,10 @@ const updateSchema = Joi.object().keys({
   positions: Joi.array().items(
     position.createSchema
   ),
-  toponyme: Joi.string().custom(validObjectID).allow(null)
+  toponyme: Joi.string().custom(validObjectID).allow(null),
+  parcelles: Joi.array().items(
+    Joi.string().regex(/^[A-Z\d]+$/).length(14)
+  ).default([])
 })
 
 async function update(id, payload) {

--- a/lib/models/toponyme.js
+++ b/lib/models/toponyme.js
@@ -9,7 +9,10 @@ const createSchema = Joi.object().keys({
   nom: Joi.string().min(1).max(200).required(),
   positions: Joi.array().items(
     position.createSchema
-  )
+  ),
+  parcelles: Joi.array().items(
+    Joi.string().regex(/^[A-Z\d]+$/).length(14)
+  ).default([])
 })
 
 async function create(idBal, codeCommune, payload) {
@@ -27,6 +30,7 @@ async function create(idBal, codeCommune, payload) {
   toponyme._bal = baseLocale._id
   toponyme.commune = codeCommune
   toponyme.positions = toponyme.positions || []
+  toponyme.parcelles = toponyme.parcelles || []
 
   mongo.decorateCreation(toponyme)
 
@@ -42,7 +46,10 @@ const updateSchema = Joi.object().keys({
   nom: Joi.string().min(1).max(200),
   positions: Joi.array().items(
     position.createSchema
-  )
+  ),
+  parcelles: Joi.array().items(
+    Joi.string().regex(/^[A-Z\d]+$/).length(14)
+  ).default([])
 })
 
 async function update(id, payload) {
@@ -96,6 +103,7 @@ async function importMany(idBal, rawToponymes, options = {}) {
       toponyme._bal = idBal
       toponyme.commune = t.commune
       toponyme.positions = t.positions || []
+      toponyme.parcelles = t.parcelles || []
 
       if (t._updated && t._created) {
         toponyme._created = t._created

--- a/lib/populate/__tests__/extract-csv.js
+++ b/lib/populate/__tests__/extract-csv.js
@@ -18,7 +18,7 @@ const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;
 55326_xxxx_99999;;Nouveau Toponyme;;99999;;Maulan;segment;5.25504;48.663112;866052.5;6842698.52;;;2021-04-27
 55326_xxxx_99999;;Toponyme Vide;;99999;;Maulan;segment;5.247276;48.664948;865475.13;6842886.26;;;2021-04-27`
 
-test('import CSv file', async t => {
+test('import CSV file', async t => {
   const {isValid, accepted, numeros, voies, toponymes} = await extractFromCsv(csvFile)
 
   t.true(isValid)

--- a/lib/populate/__tests__/extract-csv.js
+++ b/lib/populate/__tests__/extract-csv.js
@@ -21,7 +21,7 @@ const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;
 test('import CSv file', async t => {
   const {isValid, accepted, numeros, voies, toponymes} = await extractFromCsv(csvFile)
 
-  t.is(isValid, true)
+  t.true(isValid)
   t.is(accepted, 15)
   t.is(numeros.length, 9)
   t.is(voies.length, 3)

--- a/lib/populate/__tests__/extract-csv.js
+++ b/lib/populate/__tests__/extract-csv.js
@@ -2,7 +2,7 @@ const test = require('ava')
 const {extractFromCsv} = require('../extract-csv')
 
 const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;entrée;5.25237;48.668935;865837.51;6843339.94;123450000QQ666|123450000KK666;;2021-04-27
+55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;entrée;5.25237;48.668935;865837.51;6843339.94;64284000BI0459|64284000BI0450;;2021-04-27
 55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;délivrance postale;5.25237;48.669494;865835.73;6843402.13;;;2021-04-27
 55326_xxxx_00002;;Nouvelle Voie avec des numéros;;2;;Maulan;entrée;5.254912;48.667116;866030.41;6843143.15;;;2021-04-27
 55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;entrée;5.255336;48.669354;866054.49;6843392.82;;;2021-04-27
@@ -26,6 +26,6 @@ test('import CSV file', async t => {
   t.is(numeros.length, 9)
   t.is(voies.length, 3)
   t.is(toponymes.length, 2)
-  t.deepEqual(numeros[0].parcelles, ['123450000QQ666', '123450000KK666'])
+  t.deepEqual(numeros[0].parcelles, ['64284000BI0459', '64284000BI0450'])
   t.is(numeros[0].numero, 1)
 })

--- a/lib/populate/__tests__/extract-csv.js
+++ b/lib/populate/__tests__/extract-csv.js
@@ -1,0 +1,31 @@
+const test = require('ava')
+const {extractFromCsv} = require('../extract-csv')
+
+const csvFile = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
+55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;entrée;5.25237;48.668935;865837.51;6843339.94;123450000QQ666|123450000KK666;;2021-04-27
+55326_xxxx_00001;;Nouvelle Voie avec des numéros;;1;;Maulan;délivrance postale;5.25237;48.669494;865835.73;6843402.13;;;2021-04-27
+55326_xxxx_00002;;Nouvelle Voie avec des numéros;;2;;Maulan;entrée;5.254912;48.667116;866030.41;6843143.15;;;2021-04-27
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;entrée;5.255336;48.669354;866054.49;6843392.82;;;2021-04-27
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;délivrance postale;5.256289;48.669914;866122.88;6843457.02;;;2021-04-27
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;bâtiment;5.25576;48.670264;866082.79;6843494.77;;;2021-04-27
+55326_xxxx_00003;;Nouvelle Voie avec des numéros;;3;;Maulan;logement;5.257137;48.670404;866183.7;6843513.22;;;2021-04-27
+55326_xxxx_00001;;voie dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255501;48.662923;866087.07;6842678.39;;;2021-04-27
+55326_xxxx_00002;;voie dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.256137;48.663057;866133.48;6842694.64;;;2021-04-27
+55326_xxxx_00001;;Voie à moitié dans un toponyme;Nouveau Toponyme;1;;Maulan;entrée;5.255077;48.6631;866055.3;6842697.21;;;2021-04-27
+55326_xxxx_00002;;Voie à moitié dans un toponyme;Nouveau Toponyme;2;;Maulan;entrée;5.254396;48.663192;866004.84;6842706.03;;;2021-04-27
+55326_xxxx_00003;;Voie à moitié dans un toponyme;;3;;Maulan;entrée;5.253747;48.663252;865956.9;6842711.29;;;2021-04-27
+55326_xxxx_00004;;Voie à moitié dans un toponyme;;4;;Maulan;entrée;5.253197;48.663013;865917.16;6842683.62;;;2021-04-27
+55326_xxxx_99999;;Nouveau Toponyme;;99999;;Maulan;segment;5.25504;48.663112;866052.5;6842698.52;;;2021-04-27
+55326_xxxx_99999;;Toponyme Vide;;99999;;Maulan;segment;5.247276;48.664948;865475.13;6842886.26;;;2021-04-27`
+
+test('import CSv file', async t => {
+  const {isValid, accepted, numeros, voies, toponymes} = await extractFromCsv(csvFile)
+
+  t.is(isValid, true)
+  t.is(accepted, 15)
+  t.is(numeros.length, 9)
+  t.is(voies.length, 3)
+  t.is(toponymes.length, 2)
+  t.deepEqual(numeros[0].parcelles, ['123450000QQ666', '123450000KK666'])
+  t.is(numeros[0].numero, 1)
+})

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -77,7 +77,7 @@ function extractData(rows, {codeCommune}) {
           commune: codeCommune,
           nom: numeroRows[0].lieudit_complement_nom,
           positions: [],
-          parcelles: numeroRows[0].cad_parcelles || null,
+          parcelles: numeroRows[0].cad_parcelles,
           _created: new Date(),
           _updated: new Date()
         }
@@ -94,7 +94,7 @@ function extractData(rows, {codeCommune}) {
         numero: numeroRows[0].numero,
         suffixe: numeroRows[0].suffixe || null,
         positions: extractPositions(numeroRows),
-        parcelles: numeroRows[0].cad_parcelles || null,
+        parcelles: numeroRows[0].cad_parcelles,
         _created: date,
         _updated: date
       }

--- a/lib/populate/extract-csv.js
+++ b/lib/populate/extract-csv.js
@@ -77,6 +77,7 @@ function extractData(rows, {codeCommune}) {
           commune: codeCommune,
           nom: numeroRows[0].lieudit_complement_nom,
           positions: [],
+          parcelles: numeroRows[0].cad_parcelles || null,
           _created: new Date(),
           _updated: new Date()
         }
@@ -93,6 +94,7 @@ function extractData(rows, {codeCommune}) {
         numero: numeroRows[0].numero,
         suffixe: numeroRows[0].suffixe || null,
         positions: extractPositions(numeroRows),
+        parcelles: numeroRows[0].cad_parcelles || null,
         _created: date,
         _updated: date
       }

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -549,4 +549,5 @@ test('get all assigned parcelles', async t => {
 
   t.is(status, 200)
   t.is(body.length, 2)
+  t.deepEqual(body, ['12345000AA0002', '12345000AA0005'])
 })

--- a/lib/routes/__tests__/base-locale.js
+++ b/lib/routes/__tests__/base-locale.js
@@ -517,3 +517,36 @@ test.serial('renew token / without admin token', async t => {
   const baseLocal = await mongo.db.collection('bases_locales').findOne({_id})
   t.is(baseLocal.token, 'coucou')
 })
+
+test('get all assigned parcelles', async t => {
+  const _id = new mongo.ObjectID()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id,
+    nom: 'foo',
+    emails: ['me@domain.co'],
+    communes: ['55326'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  await mongo.db.collection('numeros').insertOne({
+    _bal: _id,
+    numero: 1,
+    commune: '55326',
+    parcelles: ['12345000AA0002']
+  })
+
+  await mongo.db.collection('toponymes').insertOne({
+    _bal: _id,
+    commune: '55326',
+    parcelles: ['12345000AA0002', '12345000AA0005']
+  })
+
+  const {status, body} = await request(getApp())
+    .get(`/bases-locales/${_id}/communes/55326/parcelles`)
+
+  t.is(status, 200)
+  t.is(body.length, 2)
+})

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -7,7 +7,7 @@ const mongo = require('../../util/mongo')
 const routes = require('..')
 
 const GENERATED_VARS = ['_id', '_updated', '_created']
-const KEYS = ['_id', '_bal', 'commune', 'voie', 'numero', 'numeroComplet', 'positions', 'suffixe', '_created', '_updated', 'comment', 'toponyme']
+const KEYS = ['_id', '_bal', 'commune', 'voie', 'numero', 'numeroComplet', 'positions', 'suffixe', '_created', '_updated', 'comment', 'toponyme', 'parcelles']
 
 const mongod = new MongoMemoryServer()
 
@@ -69,7 +69,8 @@ test.serial('create a numero', async t => {
     suffixe: null,
     positions: [],
     comment: null,
-    toponyme: null
+    toponyme: null,
+    parcelles: []
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)
@@ -120,6 +121,47 @@ test.serial('create a numero / invalid voie', async t => {
 
   t.is(status, 404)
 })
+
+test.serial('create a numero / invalid parcelles', async t => {
+  const _idVoie = new mongo.ObjectID()
+  const _idBal = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    nom: 'foo',
+    emails: ['me@domain.tld'],
+    communes: ['12345'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: _idVoie,
+    _bal: _idBal,
+    commune: '12345',
+    nom: 'voie',
+    code: null,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status, body} = await request(getApp())
+    .post(`/voies/${_idVoie}/numeros`)
+    .set({Authorization: 'Token coucou'})
+    .send({numero: 42, parcelles: ['invalid']})
+
+  t.is(status, 400)
+  t.deepEqual(body, {
+    code: 400,
+    message: 'Invalid payload',
+    validation: {
+      parcelles: [
+        '"parcelles[0]" with value "invalid" fails to match the required pattern: /^[A-Z\\d]+$/',
+        '"parcelles[0]" length must be 14 characters long'
+      ]
+    }
+  })
+})
+
 test.serial('create a numero / without admin token', async t => {
   const _idVoie = new mongo.ObjectID()
   const _idBal = new mongo.ObjectID()
@@ -238,6 +280,7 @@ test.serial('get all numeros from a toponyme', async t => {
     voie: _idVoie,
     numero: 42,
     positions: [],
+    parcelles: [],
     comment: null,
     suffixe: 'bis',
     toponyme: _idToponyme,
@@ -266,6 +309,7 @@ test.serial('get all numeros from a toponyme', async t => {
     comment: null,
     numeroComplet: '42bis',
     positions: [],
+    parcelles: [],
     suffixe: 'bis',
     toponyme: _idToponyme.toHexString(),
     voie: {
@@ -314,6 +358,7 @@ test.serial('get a numero', async t => {
     numero: 42,
     suffixe: 'bis',
     positions: [],
+    parcelles: [],
     comment: null,
     toponyme: null,
     _created: new Date('2019-01-01'),
@@ -332,6 +377,7 @@ test.serial('get a numero', async t => {
     suffixe: 'bis',
     numeroComplet: '42bis',
     positions: [],
+    parcelles: [],
     comment: null,
     toponyme: null
   })

--- a/lib/routes/__tests__/toponymes.js
+++ b/lib/routes/__tests__/toponymes.js
@@ -7,7 +7,7 @@ const mongo = require('../../util/mongo')
 const routes = require('..')
 
 const GENERATED_VARS = ['_id', '_updated', '_created']
-const KEYS = ['_id', '_bal', 'nom', 'positions', 'commune', '_created', '_updated']
+const KEYS = ['_id', '_bal', 'nom', 'positions', 'parcelles', 'commune', '_created', '_updated']
 
 const mongod = new MongoMemoryServer()
 
@@ -53,7 +53,8 @@ test.serial('create a toponyme', async t => {
     _bal: _id.toHexString(),
     commune: '12345',
     nom: 'toponyme',
-    positions: []
+    positions: [],
+    parcelles: []
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)
@@ -164,6 +165,7 @@ test.serial('get all toponymes from a commune', async t => {
     nom: 'toponymeA',
     commune: '12345',
     positions: [],
+    parcelles: [],
     _created: new Date('2021-01-01'),
     _updated: new Date('2021-01-01')
   },
@@ -173,6 +175,7 @@ test.serial('get all toponymes from a commune', async t => {
     nom: 'toponymeB',
     commune: '12345',
     positions: [],
+    parcelles: [],
     _created: new Date('2021-01-01'),
     _updated: new Date('2021-01-01')
   },
@@ -182,6 +185,7 @@ test.serial('get all toponymes from a commune', async t => {
     nom: 'toponymeB',
     commune: '67890',
     positions: [],
+    parcelles: [],
     _created: new Date('2021-01-01'),
     _updated: new Date('2021-01-01')
   }])
@@ -218,6 +222,7 @@ test.serial('get a toponyme', async t => {
     nom: 'toponyme',
     commune: '12345',
     positions: [],
+    parcelles: [],
     _created: new Date('2021-01-01'),
     _updated: new Date('2021-01-01')
   })
@@ -230,7 +235,8 @@ test.serial('get a toponyme', async t => {
     _bal: _idBal.toHexString(),
     nom: 'toponyme',
     commune: '12345',
-    positions: []
+    positions: [],
+    parcelles: []
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)
@@ -261,6 +267,7 @@ test.serial('modify a toponyme', async t => {
     nom: 'toponyme',
     commune: '12345',
     positions: [],
+    parcelles: [],
     _created: new Date('2021-01-01'),
     _updated: new Date('2021-01-01')
   })
@@ -329,6 +336,7 @@ test.serial('delete a toponyme', async t => {
     nom: 'toponyme',
     commune: '12345',
     positions: [],
+    parcelles: [],
     _created: new Date('2021-01-01'),
     _updated: new Date('2021-01-01')
   })
@@ -367,6 +375,7 @@ test.serial('delete a toponyme / without admin token', async t => {
     nom: 'toponyme',
     commune: '12345',
     positions: [],
+    parcelles: [],
     _created: new Date('2021-01-01'),
     _updated: new Date('2021-01-01')
   })

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -208,6 +208,12 @@ app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/toponymes')
     res.send(toponymes)
   }))
 
+app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/parcelles')
+  .get(w(async (req, res) => {
+    const parcelles = await BaseLocale.getUniqParcelles(req.params.baseLocaleId, req.params.codeCommune)
+    res.send(parcelles)
+  }))
+
 app.route('/voies/:voieId')
   .get(w(async (req, res) => {
     res.send(req.voie)

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -210,7 +210,7 @@ app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/toponymes')
 
 app.route('/bases-locales/:baseLocaleId/communes/:codeCommune/parcelles')
   .get(w(async (req, res) => {
-    const parcelles = await BaseLocale.getUniqParcelles(req.params.baseLocaleId, req.params.codeCommune)
+    const parcelles = await BaseLocale.getAssignedParcelles(req.params.baseLocaleId, req.params.codeCommune)
     res.send(parcelles)
   }))
 

--- a/migrations/2021-05-20-parcelles.js
+++ b/migrations/2021-05-20-parcelles.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/* eslint no-await-in-loop: off */
+require('dotenv').config()
+const mongo = require('../lib/util/mongo')
+
+async function main() {
+  await mongo.connect()
+
+  await mongo.db.collection('numeros').updateMany({}, {$set: {parcelles: []}})
+  await mongo.db.collection('toponymes').updateMany({}, {$set: {parcelles: []}})
+
+  await mongo.disconnect()
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/migrations/2021-05-20-parcelles.js
+++ b/migrations/2021-05-20-parcelles.js
@@ -6,8 +6,8 @@ const mongo = require('../lib/util/mongo')
 async function main() {
   await mongo.connect()
 
-  await mongo.db.collection('numeros').updateMany({}, {$set: {parcelles: []}})
-  await mongo.db.collection('toponymes').updateMany({}, {$set: {parcelles: []}})
+  await mongo.db.collection('numeros').updateMany({parcelles: {$exists: false}}, {$set: {parcelles: []}})
+  await mongo.db.collection('toponymes').updateMany({parcelles: {$exists: false}}, {$set: {parcelles: []}})
 
   await mongo.disconnect()
 }


### PR DESCRIPTION
## Contexte
Cette PR a pour objectif de permettre l'attribution de parcelles cadastre à des numéros ou toponymes. Ce champ vise à compléter le format BAL 1.2 en permettant l'alimentation de `cad_parcelles`.

## Évolutions
- Ajout d'un champ `parcelles` sur les `Numero`
- Ajout d'un champ `parcelles` sur les `Toponyme`
- Export du champ `parcelles` dans le geojson
- Import/export du champ `cad_parcelles` dans le le format `CSV`
- Ajout et mise à jour des tests pour la gestion des parcelles.

## Migration
- Ajout du champ `parcelles: []` à tous les `Numero` et `Toponyme`.

----

Cette PR est liée à [editeur#347](https://github.com/etalab/editeur-bal/pull/347)
