### PR TITLE
Empêcher la mise à jour d'un numéro avec une voie nulle

### DIFF
--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -156,10 +156,37 @@ test('update a numero', async t => {
   t.is(numero.suffixe, 'bar')
   t.is(numero.comment, 'Commentaire de numéro 123 !')
   t.is(numero.positions.length, 1)
+  t.deepEqual(numero.voie, idVoie)
   t.is(Object.keys(numero).length, 10)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})
   t.notDeepEqual(numero._created, bal._updated)
+})
+
+test('update a numero / voie null', async t => {
+  const idBal = new mongo.ObjectID()
+  const idVoie = new mongo.ObjectID()
+  const _id = new mongo.ObjectID()
+
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: idBal
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: idVoie,
+    _bal: idBal,
+    commune: '12345'
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id,
+    _bal: idBal,
+    commune: '12345',
+    voie: idVoie,
+    numero: 42,
+    suffixe: 'foo',
+    positions: []
+  })
+
+  return t.throwsAsync(() => Numero.update(_id, {voie: null}), {message: 'Invalid payload'})
 })
 
 test('update a numero / no suffixe', async t => {

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -118,7 +118,7 @@ async function importMany(idBal, rawNumeros, options = {}) {
 
 const updateSchema = Joi.object().keys({
   numero: Joi.number().min(0).max(9999).integer(),
-  voie: Joi.string().custom(validObjectID).allow(null),
+  voie: Joi.string().custom(validObjectID),
   suffixe: Joi.string().regex(/^[a-z\d]+$/i).max(10).allow(null),
   comment: Joi.string().max(5000).allow(null),
   positions: Joi.array().items(


### PR DESCRIPTION
## Problème
Il est apparu que certaine BAL étaient corrompu car certain numéro n'avaient plus de voie associé.

## Résolution
Cette PR empêche la mise à jour d'un numéro avec une voie ayant pour valeur `null`.