### PR TITLE
Correction de la valeur par défaut de numero.parcelles

### DIFF
--- a/lib/models/__tests__/numero.mongo.js
+++ b/lib/models/__tests__/numero.mongo.js
@@ -137,16 +137,39 @@ test('importMany', async t => {
 
   const numero1 = {voie: idVoie, numero: 42, commune: '12345', _created: new Date('2019-01-01'), _updated: new Date('2019-01-05')}
   const numero2 = {voie: idVoie, numero: 24, commune: '12345'}
+  const numero3 = {
+    voie: idVoie,
+    numero: 55,
+    commune: '55500',
+    positions: [
+      {
+        type: 'entrée',
+        point:
+        {
+          type: 'point',
+          coordinates: [5.25237, 48.668935]
+        }
+      }
+    ],
+    parcelles: ['55326000AA0039', '55326000AA0116', '55326000AA0035']
+  }
 
-  await Numero.importMany(idBal, [numero1, numero2], {validate: false})
+  await Numero.importMany(idBal, [numero1, numero2, numero3], {validate: false})
 
   const numeros = await mongo.db.collection('numeros').find({_bal: idBal, voie: idVoie}).toArray()
-  t.is(numeros.length, 2)
+
+  t.is(numeros.length, 3)
   t.true(numeros.some(n => n.numero === 24))
   t.true(numeros.some(n => n.numero === 42))
+
   const n42 = numeros.find(n => n.numero === 42)
   t.deepEqual(n42._created, new Date('2019-01-01'))
   t.deepEqual(n42._updated, new Date('2019-01-05'))
+  t.deepEqual(n42.parcelles, [])
+  t.is(n42.parcelles.length, 0)
+
+  const n55 = numeros.find(n => n.numero === 55)
+  t.is(n55.parcelles.length, 3)
 })
 
 test('update a numero', async t => {
@@ -193,6 +216,7 @@ test('update a numero', async t => {
   t.is(numero.comment, 'Commentaire de numéro 123 !')
   t.is(numero.positions.length, 1)
   t.is(Object.keys(numero).length, 11)
+  t.deepEqual(numero.parcelles, [])
   t.deepEqual(numero.voie, idVoie)
 
   const bal = await mongo.db.collection('bases_locales').findOne({_id: idBal})

--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -102,6 +102,8 @@ async function importMany(idBal, rawNumeros, options = {}) {
 
       numero.positions = n.positions || []
 
+      numero.parcelles = n.parcelles || []
+
       if (n._updated && n._created) {
         numero._created = n._created
         numero._updated = n._updated


### PR DESCRIPTION
Lors de l'importation de plusieurs numéros, aucun argument n'était passé à numéro concernant les parcelles, ce qui entrainait un bug dans la partie front de l'application.

Cette PR ajoute une valeur par défaut à `numero.parcelles` lors de l'import multiple, pour correspondre au reste.

Par défaut, `numero.parcelles = []`