### PR TITLE
Demande de récupération de token pour une BAL en particulier

### DIFF
--- a/lib/emails/__tests__/recovery-notification.js
+++ b/lib/emails/__tests__/recovery-notification.js
@@ -1,7 +1,7 @@
 const test = require('ava')
 const formatEmail = require('../recovery-notification')
 
-test('formatEmail', t => {
+test('formatEmail - list of BAL', t => {
   const basesLocales = [
     {
       _id: '21',
@@ -116,6 +116,121 @@ test('formatEmail', t => {
     <h5>Pourquoi ce courriel vous est envoyé ?</h5>
     <p class="explaination">
       Une personne souhaite récupérer l’accès à ses Bases Adresses Locales et a communiquée cette adresse de courrier électronique.
+      Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer ce courriel.
+    </p>
+
+    <div class="signature"><i>L’équipe adresse.data.gouv.fr</i></div>
+  </div>
+</body>
+
+</html>
+`
+
+  t.is(formatEmail({basesLocales}).html, expectedTextBody)
+})
+
+test('formatEmail - only one BAL', t => {
+  const basesLocales = [
+    {
+      _id: '21',
+      token: '123456',
+      status: 'draft',
+      nom: 'BAL A'
+    }
+  ]
+
+  const expectedTextBody = `
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demande de récupération de vos Bases Adresses Locales</title>
+  <style>
+    body {
+      background-color: #F5F6F7;
+      color: #234361;
+      font-family: "SF UI Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      margin: auto;
+      padding: 25px;
+    }
+
+    li {
+      margin: 1em 0;
+    }
+
+    h5 {
+      margin: 40px 0 0;
+    }
+
+    img {
+      max-height: 45px;
+      background-color: #F5F6F7;
+    }
+
+    .container {
+      background-color: #ebeff3;
+      padding: 25px;
+    }
+
+    .title {
+      align-items: center;
+      border-bottom: 1px solid #E4E7EB;
+      justify-content: center;
+      margin-top: 35px;
+      min-height: 10em;
+      padding: 10px;
+      text-align: center;
+    }
+
+    .status {
+      padding: .4em;
+      border-radius: 4px;
+    }
+
+    .draft {
+      background-color: rgb(228, 231, 235);
+      color: rgb(66, 90, 112);
+    }
+
+    .ready-to-publish {
+      background-color: rgb(221, 235, 247);
+      color: rgb(8, 75, 138);
+    }
+
+    .published {
+      background-color: rgb(212, 238, 226);
+      color: rgb(0, 120, 62);
+    }
+
+    .explaination {
+      font-size: small;
+    }
+
+    .signature {
+      margin-top: 40px;
+    }
+  </style>
+</head>
+
+<body>
+  <div>
+    <img src="http://api.domain.tld/public/images/logo-adresse.png" alt="Logo République Française">
+  </div>
+  <div class="title">
+    <h2 style="margin:0; mso-line-height-rule:exactly;">Demande de récupération de votre Base Adresse Locale</h2><br>
+    <h3 style="margin:0; mso-line-height-rule:exactly;">Cliquez sur le lien associé pour récupérer votre Base Adresse Locale</h3>
+  </div>
+
+  <div class="container">
+    <ul>
+      <li><span class="status draft">Brouillon</span> BAL A : <a href="http://editor.domain.tld/21/123456">http://editor.domain.tld/21/123456</a></li>
+    </ul>
+
+    <h5>Pourquoi ce courriel vous est envoyé ?</h5>
+    <p class="explaination">
+      Une personne souhaite récupérer l’accès à sa Base Adresse Locale et a communiquée cette adresse de courrier électronique.
       Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer ce courriel.
     </p>
 

--- a/lib/emails/recovery-notification.js
+++ b/lib/emails/recovery-notification.js
@@ -1,14 +1,14 @@
 const {template} = require('lodash')
 const {getEditorUrl, getApiUrl} = require('./util')
 
-const bodyTemplate = template(`
+const head = `
 <!DOCTYPE html>
 <html lang="fr">
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Demande de récupération de vos Bases Adresses Locales</title>
+  <title>Demande de récupération de votre Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -75,6 +75,10 @@ const bodyTemplate = template(`
     }
   </style>
 </head>
+`
+
+const bodyTemplateList = template(`
+${head}
 
 <body>
   <div>
@@ -89,6 +93,36 @@ const bodyTemplate = template(`
     <h3>Liste des Bases Adresses Locales associées à votre adresse email :</h3>
     <ul>
       <% _.forEach(basesLocalesRevory, function(baseLocale) { %><li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li><% }); %>
+    </ul>
+
+    <h5>Pourquoi ce courriel vous est envoyé ?</h5>
+    <p class="explaination">
+      Une personne souhaite récupérer l’accès à ses Bases Adresses Locales et a communiquée cette adresse de courrier électronique.
+      Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer ce courriel.
+    </p>
+
+    <div class="signature"><i>L’équipe adresse.data.gouv.fr</i></div>
+  </div>
+</body>
+
+</html>
+`)
+
+const bodyTemplate = template(`
+${head}
+
+<body>
+  <div>
+    <img src="<%= apiUrl %>/public/images/logo-adresse.png" alt="Logo République Française">
+  </div>
+  <div class="title">
+    <h2 style="margin:0; mso-line-height-rule:exactly;">Demande de récupération de votre Base Adresse Locale</h2><br>
+    <h3 style="margin:0; mso-line-height-rule:exactly;">Cliquez sur le lien associé pour récupérer votre Base Adresse Locale</h3>
+  </div>
+
+  <div class="container">
+    <ul>
+      <li><span class="status <%- baseLocale.status %>"><%- baseLocale.statusFr %></span> <%- baseLocale.nom %> : <a href="<%- baseLocale.recoveryUrl %>"><%- baseLocale.recoveryUrl %></a></li>
     </ul>
 
     <h5>Pourquoi ce courriel vous est envoyé ?</h5>
@@ -121,9 +155,16 @@ function formatEmail(data) {
     }
   })
 
+  if (basesLocalesRevory.length === 1) {
+    return {
+      subject: 'Demande de récupération de votre Base Adresse Locale',
+      html: bodyTemplate({baseLocale: basesLocalesRevory[0], apiUrl})
+    }
+  }
+
   return {
     subject: 'Demande de récupération de vos Bases Adresses Locales',
-    html: bodyTemplate({basesLocalesRevory, apiUrl})
+    html: bodyTemplateList({basesLocalesRevory, apiUrl})
   }
 }
 

--- a/lib/emails/recovery-notification.js
+++ b/lib/emails/recovery-notification.js
@@ -8,7 +8,7 @@ const head = `
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Demande de récupération de votre Base Adresse Locale</title>
+  <title>Demande de récupération de vos Bases Adresses Locales</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -77,9 +77,7 @@ const head = `
 </head>
 `
 
-const bodyTemplateList = template(`
-${head}
-
+const bodyTemplateList = template(`${head}
 <body>
   <div>
     <img src="<%= apiUrl %>/public/images/logo-adresse.png" alt="Logo République Française">
@@ -108,9 +106,7 @@ ${head}
 </html>
 `)
 
-const bodyTemplate = template(`
-${head}
-
+const bodyTemplate = template(`${head}
 <body>
   <div>
     <img src="<%= apiUrl %>/public/images/logo-adresse.png" alt="Logo République Française">
@@ -127,7 +123,7 @@ ${head}
 
     <h5>Pourquoi ce courriel vous est envoyé ?</h5>
     <p class="explaination">
-      Une personne souhaite récupérer l’accès à ses Bases Adresses Locales et a communiquée cette adresse de courrier électronique.
+      Une personne souhaite récupérer l’accès à sa Base Adresse Locale et a communiquée cette adresse de courrier électronique.
       Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer ce courriel.
     </p>
 

--- a/lib/models/base-locale.js
+++ b/lib/models/base-locale.js
@@ -380,8 +380,14 @@ async function computeStats() {
   }
 }
 
-async function basesLocalesRecovery(userEmail) {
-  const basesLocales = await mongo.db.collection('bases_locales').find({emails: userEmail}).toArray()
+async function basesLocalesRecovery(userEmail, baseLocaleId) {
+  const filters = {emails: userEmail}
+
+  if (baseLocaleId) {
+    filters._id = mongo.parseObjectID(baseLocaleId)
+  }
+
+  const basesLocales = await mongo.db.collection('bases_locales').find({...filters}).toArray()
 
   if (basesLocales.length > 0) {
     const email = createRecoveryNotificationEmail({basesLocales})

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -150,7 +150,7 @@ app.route('/bases-locales/:baseLocaleId/upload')
 
 app.route('/bases-locales/recovery')
   .post(w(async (req, res) => {
-    await BaseLocale.basesLocalesRecovery(req.body.email)
+    await BaseLocale.basesLocalesRecovery(req.body.email, req.body.id)
     res.sendStatus(200)
   }))
 


### PR DESCRIPTION
## Contexte
Il n'est pour le moment possible que de faire une demande de récupération de token sur la totalité des BAL liées à une adresse email. Hors offrir la possibilité de faire cette demande sur une BAL spécifique pourrait permettre aux utilisateurs de retrouver et reprendre leur adressage sur une BAL indiqué par l'alerte de création.

Cette PR viendrait donc offrir une solution de résolution à [Ajout de la suppression dans l'alerte "BAL déjà existantes"](https://github.com/etalab/editeur-bal/pull/365)

## Évolution
- Ajoute de la propriété `id` attendu par la route `/bases-locales/recovery`
- Modification du contenu du mail récupération afin de démarquer l'envoi de la liste des BAL liées à l'adresse email de la l'envoi d'un BAL en particulier
