### PR TITLE
Modification du test d’exportation CSV

### DIFF
--- a/lib/export/__tests__/csv-bal.js
+++ b/lib/export/__tests__/csv-bal.js
@@ -104,7 +104,7 @@ test('exportAsCsv', async t => {
     {
       voie: voie1._id,
       commune: '54084',
-      numero: 1,
+      numero: 0,
       suffixe: 'bis',
       certifie: true,
       positions: [],
@@ -132,7 +132,7 @@ test('exportAsCsv', async t => {
 
   const csv = await exportAsCsv({voies: [voie1, voie2], toponymes: [hameau, lieuDit], numeros})
   const expected = `cle_interop;uid_adresse;voie_nom;lieudit_complement_nom;numero;suffixe;certification_commune;commune_nom;position;long;lat;x;y;cad_parcelles;source;date_der_maj
-54084_6789_00001_bis;;allée des acacias;;1;bis;1;Mont-Bonvillers;;;;;;;;2019-02-01
+54084_6789_00000_bis;;allée des acacias;;0;bis;1;Mont-Bonvillers;;;;;;;;2019-02-01
 54084_6789_00006;;allée des acacias;La Varenne;6;;0;Mont-Bonvillers;entrée;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-02-05
 54084_xxxx_99999;;La Varenne;;99999;;;Mont-Bonvillers;;;;;;;;2019-01-05
 54084_xxxx_99999;;Le Moulin;;99999;;;Mont-Bonvillers;segment;5.83315;49.324433;905967.72;6917567.98;12345000AA0001|12345000AA0002;Mairie;2019-01-05`.replace(/\n/g, '\r\n') + '\r\n'


### PR DESCRIPTION
Modification des tests d'exportation d’une Base Adresse Locale en CSV pour prendre en compte la valeur `0` sur le champ `numero`.

Fix  #242 





