### PR TITLE
Masque les commentaires en mode consultation

### DIFF
--- a/lib/models/numero.js
+++ b/lib/models/numero.js
@@ -1,5 +1,5 @@
 const Joi = require('joi')
-const {uniqBy} = require('lodash')
+const {uniqBy, omit} = require('lodash')
 const {getFilteredPayload} = require('../util/payload')
 const mongo = require('../util/mongo')
 const {validPayload} = require('../util/payload')
@@ -124,6 +124,10 @@ async function importMany(idBal, rawNumeros, options = {}) {
   }
 
   await mongo.db.collection('numeros').insertMany(numeros)
+}
+
+function filterSensitiveFields(numero) {
+  return omit(numero, 'comment')
 }
 
 const updateSchema = Joi.object().keys({
@@ -293,6 +297,7 @@ module.exports = {
   create,
   createSchema,
   importMany,
+  filterSensitiveFields,
   update,
   updateSchema,
   fetchOne,

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -223,7 +223,52 @@ test.serial('get all numeros from a voie', async t => {
     numero: 42,
     suffixe: null,
     positions: [],
-    comment: null,
+    comment: 'Bonjour !',
+    toponyme: null,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status, body} = await request(getApp())
+    .get(`/voies/${_idVoie}/numeros`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  t.is(body.length, 1)
+  t.is(body[0].comment, 'Bonjour !')
+})
+
+test.serial('get all numeros from a voie / without token', async t => {
+  const _idVoie = new mongo.ObjectID()
+  const _idBal = new mongo.ObjectID()
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    nom: 'foo',
+    emails: ['me@domain.tld'],
+    communes: ['12345'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: _idVoie,
+    _bal: _idBal,
+    commune: '12345',
+    nom: 'voie',
+    code: null,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id,
+    _bal: _idBal,
+    commune: '12345',
+    voie: _idVoie,
+    numero: 42,
+    suffixe: null,
+    positions: [],
+    comment: 'Bonjour !',
     toponyme: null,
     _created: new Date('2019-01-01'),
     _updated: new Date('2019-01-01')
@@ -234,6 +279,7 @@ test.serial('get all numeros from a voie', async t => {
 
   t.is(status, 200)
   t.is(body.length, 1)
+  t.is(body[0].comment, undefined)
 })
 
 test.serial('get all numeros from a voie / invalid voie', async t => {
@@ -283,7 +329,91 @@ test.serial('get all numeros from a toponyme', async t => {
     numero: 42,
     positions: [],
     parcelles: [],
-    comment: null,
+    comment: 'Bonjour !',
+    suffixe: 'bis',
+    toponyme: _idToponyme,
+    certifie: false,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: _idNumeroB,
+    _bal: _idBal,
+    commune: '12345',
+    voie: _idVoie,
+    numero: 24,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status, body} = await request(getApp())
+    .get(`/toponymes/${_idToponyme}/numeros`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  t.is(body.length, 1)
+  t.deepEqual(omit(body[0], GENERATED_VARS), {
+    _bal: _idBal.toHexString(),
+    commune: '12345',
+    numero: 42,
+    comment: 'Bonjour !',
+    numeroComplet: '42bis',
+    positions: [],
+    parcelles: [],
+    suffixe: 'bis',
+    toponyme: _idToponyme.toHexString(),
+    voie: {
+      _id: _idVoie.toHexString(),
+      nom: 'voie'
+    },
+    certifie: false
+  })
+  t.true(KEYS.every(k => k in body[0]))
+  t.is(Object.keys(body[0]).length, KEYS.length)
+  t.is(body[0].comment, 'Bonjour !')
+})
+
+test.serial('get all numeros from a toponyme / without token', async t => {
+  const _idVoie = new mongo.ObjectID()
+  const _idBal = new mongo.ObjectID()
+  const _idToponyme = new mongo.ObjectID()
+  const _idNumeroA = new mongo.ObjectID()
+  const _idNumeroB = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    nom: 'foo',
+    emails: ['me@domain.tld'],
+    communes: ['12345'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: _idVoie,
+    _bal: _idBal,
+    commune: '12345',
+    nom: 'voie',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('toponymes').insertOne({
+    _id: _idToponyme,
+    _bal: _idBal,
+    commune: '12345',
+    nom: 'toponyme',
+    positions: [],
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id: _idNumeroA,
+    _bal: _idBal,
+    commune: '12345',
+    voie: _idVoie,
+    numero: 42,
+    positions: [],
+    parcelles: [],
+    comment: 'Bonjour !',
     suffixe: 'bis',
     toponyme: _idToponyme,
     certifie: false,
@@ -309,7 +439,6 @@ test.serial('get all numeros from a toponyme', async t => {
     _bal: _idBal.toHexString(),
     commune: '12345',
     numero: 42,
-    comment: null,
     numeroComplet: '42bis',
     positions: [],
     parcelles: [],
@@ -321,8 +450,9 @@ test.serial('get all numeros from a toponyme', async t => {
     },
     certifie: false
   })
-  t.true(KEYS.every(k => k in body[0]))
-  t.is(Object.keys(body[0]).length, KEYS.length)
+  t.false(KEYS.every(k => k in body[0]))
+  t.is(Object.keys(body[0]).length, KEYS.length - 1)
+  t.is(body[0].comment, undefined)
 })
 
 test.serial('get all numeros from a toponyme / invalid toponyme', async t => {

--- a/lib/routes/__tests__/numeros.js
+++ b/lib/routes/__tests__/numeros.js
@@ -462,7 +462,7 @@ test.serial('get all numeros from a toponyme / invalid toponyme', async t => {
   t.is(status, 404)
 })
 
-test.serial('get a numero', async t => {
+test.serial('get a numero / no token', async t => {
   const _idVoie = new mongo.ObjectID()
   const _idBal = new mongo.ObjectID()
   const _id = new mongo.ObjectID()
@@ -493,7 +493,7 @@ test.serial('get a numero', async t => {
     suffixe: 'bis',
     positions: [],
     parcelles: [],
-    comment: null,
+    comment: 'Bonjour !',
     toponyme: null,
     certifie: false,
     _created: new Date('2019-01-01'),
@@ -513,12 +513,73 @@ test.serial('get a numero', async t => {
     numeroComplet: '42bis',
     positions: [],
     parcelles: [],
-    comment: null,
+    toponyme: null,
+    certifie: false
+  })
+  t.false(KEYS.every(k => k in body))
+  t.is(Object.keys(body).length, KEYS.length - 1)
+  t.is(body.comment, undefined)
+})
+
+test.serial('get a numero / with token', async t => {
+  const _idVoie = new mongo.ObjectID()
+  const _idBal = new mongo.ObjectID()
+  const _id = new mongo.ObjectID()
+  await mongo.db.collection('bases_locales').insertOne({
+    _id: _idBal,
+    nom: 'foo',
+    emails: ['me@domain.tld'],
+    communes: ['12345'],
+    token: 'coucou',
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('voies').insertOne({
+    _id: _idVoie,
+    _bal: _idBal,
+    commune: '12345',
+    nom: 'voie',
+    code: null,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+  await mongo.db.collection('numeros').insertOne({
+    _id,
+    _bal: _idBal,
+    commune: '12345',
+    voie: _idVoie,
+    numero: 42,
+    suffixe: 'bis',
+    positions: [],
+    parcelles: [],
+    comment: 'Bonjour !',
+    toponyme: null,
+    certifie: false,
+    _created: new Date('2019-01-01'),
+    _updated: new Date('2019-01-01')
+  })
+
+  const {status, body} = await request(getApp())
+    .get(`/numeros/${_id}`)
+    .set({Authorization: 'Token coucou'})
+
+  t.is(status, 200)
+  t.deepEqual(omit(body, GENERATED_VARS), {
+    _bal: _idBal.toHexString(),
+    voie: _idVoie.toHexString(),
+    commune: '12345',
+    comment: 'Bonjour !',
+    numero: 42,
+    suffixe: 'bis',
+    numeroComplet: '42bis',
+    positions: [],
+    parcelles: [],
     toponyme: null,
     certifie: false
   })
   t.true(KEYS.every(k => k in body))
   t.is(Object.keys(body).length, KEYS.length)
+  t.is(body.comment, 'Bonjour !')
 })
 
 test.serial('get a numero / invalid numero', async t => {

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -267,7 +267,16 @@ app.route('/voies/:voieId/numeros')
   }))
   .get(w(async (req, res) => {
     const numeros = await Numero.fetchAll(req.voie._id)
-    res.send(numeros.map(n => Numero.expandModel(n)))
+
+    if (req.isAdmin) {
+      res.send(numeros.map(n => Numero.expandModel(n)))
+    } else {
+      const filtered = numeros.map(n => {
+        return Numero.filterSensitiveFields(n)
+      })
+
+      res.send(filtered.map(n => Numero.expandModel(n)))
+    }
   }))
 
 app.route('/voies/:voieId/batch')
@@ -305,7 +314,15 @@ app.route('/toponymes/:toponymeId')
 app.route('/toponymes/:toponymeId/numeros')
   .get(w(async (req, res) => {
     const numeros = await Numero.fetchByToponyme(req.toponyme._id)
-    res.send(numeros.map(n => Numero.expandModel(n)))
+    if (req.isAdmin) {
+      res.send(numeros.map(n => Numero.expandModel(n)))
+    } else {
+      const filtered = numeros.map(n => {
+        return Numero.filterSensitiveFields(n)
+      })
+
+      res.send(filtered.map(n => Numero.expandModel(n)))
+    }
   }))
 
 app.use('/stats', stats)

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -287,7 +287,13 @@ app.route('/voies/:voieId/batch')
 
 app.route('/numeros/:numeroId')
   .get(w(async (req, res) => {
-    res.send(Numero.expandModel(req.numero))
+    if (req.isAdmin) {
+      res.send(Numero.expandModel(req.numero))
+    } else {
+      const filtered = Numero.filterSensitiveFields(req.numero)
+
+      res.send(Numero.expandModel(filtered))
+    }
   }))
   .put(ensureIsAdmin, w(async (req, res) => {
     const numero = await Numero.update(req.numero._id, req.body)


### PR DESCRIPTION
Cette PR propose de masquer les commentaires des numéros en mode consultation.

Les routes `/voie/id_voie/numeros` , `/toponymes/id_toponyme/numeros` et `/numeros/numero_id` attendent désormais un jeton d'authentification.
Si aucun jeton n'est envoyé, elles retournent un numéro sans commentaire.

### Routes modifiées :
- GET `/voie/id_voie/numeros`
- GET `/toponymes/id_toponyme/numeros`
- GET `/numeros/numero_id`

   
_Cette modification fait suite à l'issue [#394](https://github.com/etalab/editeur-bal/issues/394) de l'[editeur-bal](https://github.com/etalab/editeur-bal)._

---
### Détails :

- Ajout de la fonction `filterSensitiveFields` au modèle `Numero`
- Modification des routes pour prendre en compte le jeton d'authentification.
- Ajout de tests pour vérifier la présence ou non des commentaires.
