### PR TITLE
Ajout d'un liens bruts pour faciliter l'administration des Bases Adresses Locales par courriel

### DIFF
--- a/lib/emails/__tests__/bal-publication-notification.js
+++ b/lib/emails/__tests__/bal-publication-notification.js
@@ -15,7 +15,7 @@ test('formatEmail', t => {
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Création d’une nouvelle Base Adresse Locale</title>
+  <title>Publication de votre Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -101,7 +101,12 @@ test('formatEmail', t => {
     <p>En cas de problème, l'accès à la <b><i>Base Adresse Locale</i></b> peut être réinitialisé sur demande.</p>
 
     <span><i>L’équipe adresse.data.gouv.fr</i></span>
-    <p class="infos"><small><i>Jeton d’administration (information expert)&nbsp;: 123456</i></small></p>
+    <p class="infos">
+      <small>
+        <i>Jeton d’administration (information expert)&nbsp;: 123456</i>
+      </small>
+      <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b>http://editor.domain.tld/42/123456</b></div>
+    </p>
   </div>
 </body>
 
@@ -124,7 +129,7 @@ test('formatEmail / without nom', t => {
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Création d’une nouvelle Base Adresse Locale</title>
+  <title>Publication de votre Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -210,7 +215,12 @@ test('formatEmail / without nom', t => {
     <p>En cas de problème, l'accès à la <b><i>Base Adresse Locale</i></b> peut être réinitialisé sur demande.</p>
 
     <span><i>L’équipe adresse.data.gouv.fr</i></span>
-    <p class="infos"><small><i>Jeton d’administration (information expert)&nbsp;: 123456</i></small></p>
+    <p class="infos">
+      <small>
+        <i>Jeton d’administration (information expert)&nbsp;: 123456</i>
+      </small>
+      <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b>http://editor.domain.tld/42/123456</b></div>
+    </p>
   </div>
 </body>
 

--- a/lib/emails/__tests__/new-admin-notification.js
+++ b/lib/emails/__tests__/new-admin-notification.js
@@ -15,7 +15,7 @@ test('formatEmail', t => {
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Création d’une nouvelle Base Adresse Locale</title>
+  <title>Invitation à l‘administration d‘une Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -89,7 +89,12 @@ test('formatEmail', t => {
     <p>En cas de problème, l'accès à la <b><i>Base Adresse Locale</i></b> peut être réinitialisé sur demande.</p>
 
     <p><i>L’équipe adresse.data.gouv.fr</i></p>
-    <p class="infos"><small><i>Nouveau jeton (information expert)&nbsp;: 123456</i></small></p>
+    <p class="infos">
+      <small>
+        <i>Nouveau jeton (information expert)&nbsp;: 123456</i>
+      </small>
+      <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b>http://editor.domain.tld/42/123456</b></div>
+    </p>
   </div>
 </body>
 
@@ -112,7 +117,7 @@ test('formatEmail / without nom', t => {
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Création d’une nouvelle Base Adresse Locale</title>
+  <title>Invitation à l‘administration d‘une Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -186,7 +191,12 @@ test('formatEmail / without nom', t => {
     <p>En cas de problème, l'accès à la <b><i>Base Adresse Locale</i></b> peut être réinitialisé sur demande.</p>
 
     <p><i>L’équipe adresse.data.gouv.fr</i></p>
-    <p class="infos"><small><i>Nouveau jeton (information expert)&nbsp;: 123456</i></small></p>
+    <p class="infos">
+      <small>
+        <i>Nouveau jeton (information expert)&nbsp;: 123456</i>
+      </small>
+      <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b>http://editor.domain.tld/42/123456</b></div>
+    </p>
   </div>
 </body>
 

--- a/lib/emails/__tests__/token-renewal-notification.js
+++ b/lib/emails/__tests__/token-renewal-notification.js
@@ -15,7 +15,7 @@ test('formatEmail', t => {
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Création d’une nouvelle Base Adresse Locale</title>
+  <title>Renouvelement de jeton de Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -86,7 +86,12 @@ test('formatEmail', t => {
     <p>Vous pouvez désormais administrer votre <b><i>Base Adresse Locale</i></b> à partir de la page suivante:</p>
     <span class="forceWhiteLink"><button><a href="http://editor.domain.tld/42/123456" target="blank">Gérer mes adresses</a></button></span>
     <p><i>L’équipe adresse.data.gouv.fr</i></p>
-    <p class="infos"><small><i>Nouveau jeton (information expert)&nbsp;: 123456</i></small></p>
+    <p class="infos">
+      <small>
+        <i>Nouveau jeton (information expert)&nbsp;: 123456</i>
+      </small>
+      <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b>http://editor.domain.tld/42/123456</b></div>
+    </p>
   </div>
 </body>
 
@@ -109,7 +114,7 @@ test('formatEmail / without nom', t => {
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Création d’une nouvelle Base Adresse Locale</title>
+  <title>Renouvelement de jeton de Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -180,7 +185,12 @@ test('formatEmail / without nom', t => {
     <p>Vous pouvez désormais administrer votre <b><i>Base Adresse Locale</i></b> à partir de la page suivante:</p>
     <span class="forceWhiteLink"><button><a href="http://editor.domain.tld/42/123456" target="blank">Gérer mes adresses</a></button></span>
     <p><i>L’équipe adresse.data.gouv.fr</i></p>
-    <p class="infos"><small><i>Nouveau jeton (information expert)&nbsp;: 123456</i></small></p>
+    <p class="infos">
+      <small>
+        <i>Nouveau jeton (information expert)&nbsp;: 123456</i>
+      </small>
+      <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b>http://editor.domain.tld/42/123456</b></div>
+    </p>
   </div>
 </body>
 

--- a/lib/emails/bal-publication-notification.js
+++ b/lib/emails/bal-publication-notification.js
@@ -8,7 +8,7 @@ const bodyTemplate = template(`
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Création d’une nouvelle Base Adresse Locale</title>
+  <title>Publication de votre Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -94,7 +94,12 @@ const bodyTemplate = template(`
     <p>En cas de problème, l'accès à la <b><i>Base Adresse Locale</i></b> peut être réinitialisé sur demande.</p>
 
     <span><i>L’équipe adresse.data.gouv.fr</i></span>
-    <p class="infos"><small><i>Jeton d’administration (information expert)&nbsp;: <%= baseLocale.token %></i></small></p>
+    <p class="infos">
+      <small>
+        <i>Jeton d’administration (information expert)&nbsp;: <%= baseLocale.token %></i>
+      </small>
+      <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b><%= editorUrl %></b></div>
+    </p>
   </div>
 </body>
 
@@ -107,7 +112,7 @@ function formatEmail(data) {
   const apiUrl = getApiUrl()
 
   return {
-    subject: 'Création d’une nouvelle Base Adresse Locale',
+    subject: 'Publication de votre Base Adresse Locale',
     html: bodyTemplate({baseLocale, editorUrl, apiUrl})
   }
 }

--- a/lib/emails/new-admin-notification.js
+++ b/lib/emails/new-admin-notification.js
@@ -8,7 +8,7 @@ const bodyTemplate = template(`
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Création d’une nouvelle Base Adresse Locale</title>
+  <title>Invitation à l‘administration d‘une Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -82,7 +82,12 @@ const bodyTemplate = template(`
     <p>En cas de problème, l'accès à la <b><i>Base Adresse Locale</i></b> peut être réinitialisé sur demande.</p>
 
     <p><i>L’équipe adresse.data.gouv.fr</i></p>
-    <p class="infos"><small><i>Nouveau jeton (information expert)&nbsp;: <%= baseLocale.token %></i></small></p>
+    <p class="infos">
+      <small>
+        <i>Nouveau jeton (information expert)&nbsp;: <%= baseLocale.token %></i>
+      </small>
+      <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b><%= editorUrl %></b></div>
+    </p>
   </div>
 </body>
 

--- a/lib/emails/token-renewal-notification.js
+++ b/lib/emails/token-renewal-notification.js
@@ -8,7 +8,7 @@ const bodyTemplate = template(`
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Création d’une nouvelle Base Adresse Locale</title>
+  <title>Renouvelement de jeton de Base Adresse Locale</title>
   <style>
     body {
       background-color: #F5F6F7;
@@ -79,7 +79,12 @@ const bodyTemplate = template(`
     <p>Vous pouvez désormais administrer votre <b><i>Base Adresse Locale</i></b> à partir de la page suivante:</p>
     <span class="forceWhiteLink"><button><a href="<%= editorUrl %>" target="blank">Gérer mes adresses</a></button></span>
     <p><i>L’équipe adresse.data.gouv.fr</i></p>
-    <p class="infos"><small><i>Nouveau jeton (information expert)&nbsp;: <%= baseLocale.token %></i></small></p>
+    <p class="infos">
+      <small>
+        <i>Nouveau jeton (information expert)&nbsp;: <%= baseLocale.token %></i>
+      </small>
+      <div>Si le bouton ci-dessus ne fonctionne pas, collez l’URL suivante dans la barre d’adresse de votre navigateur : <b><%= editorUrl %></b></div>
+    </p>
   </div>
 </body>
 


### PR DESCRIPTION
## Contexte : 
Lorsqu'un utilisateur ajoute un administrateur à sa Base Adresse Locale, le courriel reçu contient un bouton qui permet d'ouvrir l'éditeur en incluant le jeton d'administration.

Certains utilisateurs, généralement ceux qui utilisent un logiciel de mail spécifique ou ne respectant pas les standards, ne peuvent pas utiliser ce bouton.

## Solution : 

Cette PR ajoute un lien, en plus du bouton, pour permettre à l'utilisateur de copier / coller le lien directement dans son navigateur.

## +

Après discussion, nous avons décidé d'ajouter ce lien dans tous les courriels concernés : 
- Courriel de publication d'une Base Adresse Locale
- Courriel de renouvellement de jeton
- Courriel d'ajout d'un administrateur
- Correction de la balise <title /> de certain mail 

