### PR TITLE
fix: precedents communes multi fusions

### DIFF
--- a/communes-precedentes-by-chef-lieu.json
+++ b/communes-precedentes-by-chef-lieu.json
@@ -1,5 +1,10203 @@
 [
   {
+    "code": "01015",
+    "nom": "Arboys en Bugey",
+    "anciennesCommunes": [
+      {
+        "code": "01015",
+        "nom": "Arbignieu"
+      },
+      {
+        "code": "01340",
+        "nom": "Saint-Bois"
+      }
+    ]
+  },
+  {
+    "code": "01025",
+    "nom": "Bâgé-Dommartin",
+    "anciennesCommunes": [
+      {
+        "code": "01025",
+        "nom": "Bâgé-la-Ville"
+      },
+      {
+        "code": "01144",
+        "nom": "Dommartin"
+      }
+    ]
+  },
+  {
+    "code": "01033",
+    "nom": "Valserhône",
+    "anciennesCommunes": [
+      {
+        "code": "01033",
+        "nom": "Bellegarde-sur-Valserine"
+      },
+      {
+        "code": "01091",
+        "nom": "Châtillon-en-Michaille"
+      },
+      {
+        "code": "01205",
+        "nom": "Lancrans"
+      }
+    ]
+  },
+  {
+    "code": "01036",
+    "nom": "Valromey-sur-Séran",
+    "anciennesCommunes": [
+      {
+        "code": "01036",
+        "nom": "Belmont-Luthézieu"
+      },
+      {
+        "code": "01221",
+        "nom": "Lompnieu"
+      },
+      {
+        "code": "01414",
+        "nom": "Sutrieu"
+      },
+      {
+        "code": "01442",
+        "nom": "Vieu"
+      }
+    ]
+  },
+  {
+    "code": "01080",
+    "nom": "Champdor-Corcelles",
+    "anciennesCommunes": [
+      {
+        "code": "01080",
+        "nom": "Champdor"
+      },
+      {
+        "code": "01119",
+        "nom": "Corcelles"
+      }
+    ]
+  },
+  {
+    "code": "01095",
+    "nom": "Nivigne et Suran",
+    "anciennesCommunes": [
+      {
+        "code": "01095",
+        "nom": "Chavannes-sur-Suran"
+      },
+      {
+        "code": "01172",
+        "nom": "Germagnat"
+      }
+    ]
+  },
+  {
+    "code": "01098",
+    "nom": "Chazey-Bons",
+    "anciennesCommunes": [
+      {
+        "code": "01098",
+        "nom": "Chazey-Bons"
+      },
+      {
+        "code": "01316",
+        "nom": "Pugieu"
+      }
+    ]
+  },
+  {
+    "code": "01130",
+    "nom": "Bresse Vallons",
+    "anciennesCommunes": [
+      {
+        "code": "01130",
+        "nom": "Cras-sur-Reyssouze"
+      },
+      {
+        "code": "01154",
+        "nom": "Étrez"
+      }
+    ]
+  },
+  {
+    "code": "01138",
+    "nom": "Culoz-Béon",
+    "anciennesCommunes": [
+      {
+        "code": "01039",
+        "nom": "Béon"
+      },
+      {
+        "code": "01138",
+        "nom": "Culoz"
+      }
+    ]
+  },
+  {
+    "code": "01143",
+    "nom": "Divonne-les-Bains",
+    "anciennesCommunes": [
+      {
+        "code": "01143",
+        "nom": "Divonne-les-Bains"
+      }
+    ]
+  },
+  {
+    "code": "01185",
+    "nom": "Plateau d'Hauteville",
+    "anciennesCommunes": [
+      {
+        "code": "01122",
+        "nom": "Cormaranche-en-Bugey"
+      },
+      {
+        "code": "01185",
+        "nom": "Hauteville-Lompnes"
+      },
+      {
+        "code": "01186",
+        "nom": "Hostiaz"
+      },
+      {
+        "code": "01417",
+        "nom": "Thézillieu"
+      }
+    ]
+  },
+  {
+    "code": "01187",
+    "nom": "Haut Valromey",
+    "anciennesCommunes": [
+      {
+        "code": "01187",
+        "nom": "Hotonnes"
+      },
+      {
+        "code": "01330",
+        "nom": "Ruffieu"
+      },
+      {
+        "code": "01176",
+        "nom": "Le Grand-Abergement"
+      },
+      {
+        "code": "01292",
+        "nom": "Le Petit-Abergement"
+      },
+      {
+        "code": "01409",
+        "nom": "Songieu"
+      }
+    ]
+  },
+  {
+    "code": "01204",
+    "nom": "Le Poizat-Lalleyriat",
+    "anciennesCommunes": [
+      {
+        "code": "01204",
+        "nom": "Lalleyriat"
+      },
+      {
+        "code": "01300",
+        "nom": "Le Poizat"
+      }
+    ]
+  },
+  {
+    "code": "01215",
+    "nom": "Surjoux-Lhopital",
+    "anciennesCommunes": [
+      {
+        "code": "01215",
+        "nom": "Lhôpital"
+      },
+      {
+        "code": "01413",
+        "nom": "Surjoux"
+      }
+    ]
+  },
+  {
+    "code": "01227",
+    "nom": "Magnieu",
+    "anciennesCommunes": [
+      {
+        "code": "01227",
+        "nom": "Magnieu"
+      },
+      {
+        "code": "01341",
+        "nom": "Saint-Champ"
+      }
+    ]
+  },
+  {
+    "code": "01283",
+    "nom": "Oyonnax",
+    "anciennesCommunes": [
+      {
+        "code": "01283",
+        "nom": "Oyonnax"
+      }
+    ]
+  },
+  {
+    "code": "01286",
+    "nom": "Parves et Nattages",
+    "anciennesCommunes": [
+      {
+        "code": "01271",
+        "nom": "Nattages"
+      },
+      {
+        "code": "01286",
+        "nom": "Parves"
+      }
+    ]
+  },
+  {
+    "code": "01338",
+    "nom": "Groslée-Saint-Benoit",
+    "anciennesCommunes": [
+      {
+        "code": "01182",
+        "nom": "Groslée"
+      },
+      {
+        "code": "01338",
+        "nom": "Saint-Benoît"
+      }
+    ]
+  },
+  {
+    "code": "01426",
+    "nom": "Val-Revermont",
+    "anciennesCommunes": [
+      {
+        "code": "01312",
+        "nom": "Pressiat"
+      },
+      {
+        "code": "01426",
+        "nom": "Treffort-Cuisiat"
+      }
+    ]
+  },
+  {
+    "code": "01453",
+    "nom": "Arvière-en-Valromey",
+    "anciennesCommunes": [
+      {
+        "code": "01059",
+        "nom": "Brénaz"
+      },
+      {
+        "code": "01097",
+        "nom": "Chavornay"
+      },
+      {
+        "code": "01218",
+        "nom": "Lochieu"
+      },
+      {
+        "code": "01453",
+        "nom": "Virieu-le-Petit"
+      }
+    ]
+  },
+  {
+    "code": "02018",
+    "nom": "Anizy-le-Grand",
+    "anciennesCommunes": [
+      {
+        "code": "02018",
+        "nom": "Anizy-le-Château"
+      },
+      {
+        "code": "02301",
+        "nom": "Faucoucourt"
+      },
+      {
+        "code": "02434",
+        "nom": "Lizy"
+      }
+    ]
+  },
+  {
+    "code": "02053",
+    "nom": "Vallées en Champagne",
+    "anciennesCommunes": [
+      {
+        "code": "02053",
+        "nom": "Baulne-en-Brie"
+      },
+      {
+        "code": "02161",
+        "nom": "La Chapelle-Monthodon"
+      },
+      {
+        "code": "02669",
+        "nom": "Saint-Agnan"
+      }
+    ]
+  },
+  {
+    "code": "02054",
+    "nom": "Bazoches-et-Saint-Thibaut",
+    "anciennesCommunes": [
+      {
+        "code": "02054",
+        "nom": "Bazoches-sur-Vesles"
+      },
+      {
+        "code": "02695",
+        "nom": "Saint-Thibaut"
+      }
+    ]
+  },
+  {
+    "code": "02153",
+    "nom": "Cessières-Suzy",
+    "anciennesCommunes": [
+      {
+        "code": "02153",
+        "nom": "Cessières"
+      },
+      {
+        "code": "02733",
+        "nom": "Suzy"
+      }
+    ]
+  },
+  {
+    "code": "02360",
+    "nom": "Villeneuve-sur-Aisne",
+    "anciennesCommunes": [
+      {
+        "code": "02360",
+        "nom": "Guignicourt"
+      },
+      {
+        "code": "02475",
+        "nom": "Menneville"
+      }
+    ]
+  },
+  {
+    "code": "02439",
+    "nom": "Les Septvallons",
+    "anciennesCommunes": [
+      {
+        "code": "02348",
+        "nom": "Glennes"
+      },
+      {
+        "code": "02439",
+        "nom": "Longueval-Barbonval"
+      },
+      {
+        "code": "02479",
+        "nom": "Merval"
+      },
+      {
+        "code": "02597",
+        "nom": "Perles"
+      },
+      {
+        "code": "02646",
+        "nom": "Révillon"
+      },
+      {
+        "code": "02771",
+        "nom": "Vauxcéré"
+      },
+      {
+        "code": "02811",
+        "nom": "Villers-en-Prayères"
+      }
+    ]
+  },
+  {
+    "code": "02458",
+    "nom": "Dhuys et Morin-en-Brie",
+    "anciennesCommunes": [
+      {
+        "code": "02026",
+        "nom": "Artonges"
+      },
+      {
+        "code": "02147",
+        "nom": "La Celle-sous-Montmirail"
+      },
+      {
+        "code": "02325",
+        "nom": "Fontenelle-en-Brie"
+      },
+      {
+        "code": "02458",
+        "nom": "Marchais-en-Brie"
+      }
+    ]
+  },
+  {
+    "code": "02564",
+    "nom": "Bernoy-le-Château",
+    "anciennesCommunes": [
+      {
+        "code": "02077",
+        "nom": "Berzy-le-Sec"
+      },
+      {
+        "code": "02564",
+        "nom": "Noyant-et-Aconin"
+      }
+    ]
+  },
+  {
+    "code": "02589",
+    "nom": "Pargny-et-Filain",
+    "anciennesCommunes": [
+      {
+        "code": "02311",
+        "nom": "Filain"
+      },
+      {
+        "code": "02589",
+        "nom": "Pargny-Filain"
+      }
+    ]
+  },
+  {
+    "code": "03158",
+    "nom": "Haut-Bocage",
+    "anciennesCommunes": [
+      {
+        "code": "03123",
+        "nom": "Givarlais"
+      },
+      {
+        "code": "03153",
+        "nom": "Louroux-Hodement"
+      },
+      {
+        "code": "03158",
+        "nom": "Maillet"
+      }
+    ]
+  },
+  {
+    "code": "03168",
+    "nom": "Meaulne-Vitray",
+    "anciennesCommunes": [
+      {
+        "code": "03168",
+        "nom": "Meaulne"
+      },
+      {
+        "code": "03318",
+        "nom": "Vitray"
+      }
+    ]
+  },
+  {
+    "code": "04033",
+    "nom": "Ubaye-Serre-Ponçon",
+    "anciennesCommunes": [
+      {
+        "code": "04033",
+        "nom": "La Bréole"
+      },
+      {
+        "code": "04198",
+        "nom": "Saint-Vincent-les-Forts"
+      }
+    ]
+  },
+  {
+    "code": "04120",
+    "nom": "Val d'Oronaye",
+    "anciennesCommunes": [
+      {
+        "code": "04100",
+        "nom": "Larche"
+      },
+      {
+        "code": "04120",
+        "nom": "Meyronnes"
+      }
+    ]
+  },
+  {
+    "code": "04208",
+    "nom": "Simiane-la-Rotonde",
+    "anciennesCommunes": [
+      {
+        "code": "04208",
+        "nom": "Simiane-la-Rotonde"
+      }
+    ]
+  },
+  {
+    "code": "05001",
+    "nom": "Abriès-Ristolas",
+    "anciennesCommunes": [
+      {
+        "code": "05001",
+        "nom": "Abriès"
+      },
+      {
+        "code": "05120",
+        "nom": "Ristolas"
+      }
+    ]
+  },
+  {
+    "code": "05024",
+    "nom": "Valdoule",
+    "anciennesCommunes": [
+      {
+        "code": "05024",
+        "nom": "Bruis"
+      },
+      {
+        "code": "05088",
+        "nom": "Montmorin"
+      },
+      {
+        "code": "05150",
+        "nom": "Sainte-Marie"
+      }
+    ]
+  },
+  {
+    "code": "05039",
+    "nom": "Aubessagne",
+    "anciennesCommunes": [
+      {
+        "code": "05039",
+        "nom": "Chauffayer"
+      },
+      {
+        "code": "05043",
+        "nom": "Les Costes"
+      },
+      {
+        "code": "05141",
+        "nom": "Saint-Eusèbe-en-Champsaur"
+      }
+    ]
+  },
+  {
+    "code": "05053",
+    "nom": "Garde-Colombe",
+    "anciennesCommunes": [
+      {
+        "code": "05053",
+        "nom": "Eyguians"
+      },
+      {
+        "code": "05069",
+        "nom": "Lagrand"
+      },
+      {
+        "code": "05143",
+        "nom": "Saint-Genis"
+      }
+    ]
+  },
+  {
+    "code": "05101",
+    "nom": "Vallouise-Pelvoux",
+    "anciennesCommunes": [
+      {
+        "code": "05101",
+        "nom": "Pelvoux"
+      },
+      {
+        "code": "05175",
+        "nom": "Vallouise"
+      }
+    ]
+  },
+  {
+    "code": "05118",
+    "nom": "Val Buëch-Méouge",
+    "anciennesCommunes": [
+      {
+        "code": "05005",
+        "nom": "Antonaves"
+      },
+      {
+        "code": "05034",
+        "nom": "Châteauneuf-de-Chabre"
+      },
+      {
+        "code": "05118",
+        "nom": "Ribiers"
+      }
+    ]
+  },
+  {
+    "code": "05132",
+    "nom": "Saint-Bonnet-en-Champsaur",
+    "anciennesCommunes": [
+      {
+        "code": "05020",
+        "nom": "Bénévent-et-Charbillac"
+      },
+      {
+        "code": "05067",
+        "nom": "Les Infournas"
+      },
+      {
+        "code": "05132",
+        "nom": "Saint-Bonnet-en-Champsaur"
+      }
+    ]
+  },
+  {
+    "code": "05139",
+    "nom": "Dévoluy",
+    "anciennesCommunes": [
+      {
+        "code": "05002",
+        "nom": "Agnières-en-Dévoluy"
+      },
+      {
+        "code": "05042",
+        "nom": "La Cluse"
+      },
+      {
+        "code": "05138",
+        "nom": "Saint-Disdier"
+      },
+      {
+        "code": "05139",
+        "nom": "Saint-Étienne-en-Dévoluy"
+      }
+    ]
+  },
+  {
+    "code": "07011",
+    "nom": "Vallées-d'Antraigues-Asperjoc",
+    "anciennesCommunes": [
+      {
+        "code": "07011",
+        "nom": "Antraigues-sur-Volane"
+      },
+      {
+        "code": "07016",
+        "nom": "Asperjoc"
+      }
+    ]
+  },
+  {
+    "code": "07103",
+    "nom": "Saint-Julien-d'Intres",
+    "anciennesCommunes": [
+      {
+        "code": "07103",
+        "nom": "Intres"
+      },
+      {
+        "code": "07252",
+        "nom": "Saint-Julien-Boutières"
+      }
+    ]
+  },
+  {
+    "code": "07165",
+    "nom": "Belsentes",
+    "anciennesCommunes": [
+      {
+        "code": "07165",
+        "nom": "Nonières"
+      },
+      {
+        "code": "07256",
+        "nom": "Saint-Julien-Labrousse"
+      }
+    ]
+  },
+  {
+    "code": "07262",
+    "nom": "Saint-Laurent-les-Bains-Laval-d'Aurelle",
+    "anciennesCommunes": [
+      {
+        "code": "07135",
+        "nom": "Laval-d'Aurelle"
+      },
+      {
+        "code": "07262",
+        "nom": "Saint-Laurent-les-Bains"
+      }
+    ]
+  },
+  {
+    "code": "08053",
+    "nom": "Bazeilles",
+    "anciennesCommunes": [
+      {
+        "code": "08053",
+        "nom": "Bazeilles"
+      },
+      {
+        "code": "08294",
+        "nom": "La Moncelle"
+      },
+      {
+        "code": "08371",
+        "nom": "Rubécourt-et-Lamécourt"
+      },
+      {
+        "code": "08475",
+        "nom": "Villers-Cernay"
+      }
+    ]
+  },
+  {
+    "code": "08115",
+    "nom": "Chémery-Chéhéry",
+    "anciennesCommunes": [
+      {
+        "code": "08114",
+        "nom": "Chéhéry"
+      },
+      {
+        "code": "08115",
+        "nom": "Chémery-sur-Bar"
+      }
+    ]
+  },
+  {
+    "code": "08116",
+    "nom": "Bairon et ses environs",
+    "anciennesCommunes": [
+      {
+        "code": "08007",
+        "nom": "Les Alleux"
+      },
+      {
+        "code": "08116",
+        "nom": "Le Chesne"
+      },
+      {
+        "code": "08261",
+        "nom": "Louvergny"
+      }
+    ]
+  },
+  {
+    "code": "08145",
+    "nom": "Douzy",
+    "anciennesCommunes": [
+      {
+        "code": "08145",
+        "nom": "Douzy"
+      },
+      {
+        "code": "08267",
+        "nom": "Mairy"
+      }
+    ]
+  },
+  {
+    "code": "08173",
+    "nom": "Flize",
+    "anciennesCommunes": [
+      {
+        "code": "08042",
+        "nom": "Balaives-et-Butz"
+      },
+      {
+        "code": "08079",
+        "nom": "Boutancourt"
+      },
+      {
+        "code": "08152",
+        "nom": "Élan"
+      },
+      {
+        "code": "08173",
+        "nom": "Flize"
+      }
+    ]
+  },
+  {
+    "code": "08198",
+    "nom": "Grandpré",
+    "anciennesCommunes": [
+      {
+        "code": "08198",
+        "nom": "Grandpré"
+      },
+      {
+        "code": "08441",
+        "nom": "Termes"
+      }
+    ]
+  },
+  {
+    "code": "08311",
+    "nom": "Mouzon",
+    "anciennesCommunes": [
+      {
+        "code": "08009",
+        "nom": "Amblimont"
+      },
+      {
+        "code": "08311",
+        "nom": "Mouzon"
+      }
+    ]
+  },
+  {
+    "code": "08319",
+    "nom": "Neuville-lez-Beaulieu",
+    "anciennesCommunes": [
+      {
+        "code": "08319",
+        "nom": "Neuville-lez-Beaulieu"
+      }
+    ]
+  },
+  {
+    "code": "08344",
+    "nom": "Prez",
+    "anciennesCommunes": [
+      {
+        "code": "08344",
+        "nom": "Prez"
+      }
+    ]
+  },
+  {
+    "code": "08439",
+    "nom": "Tannay-le-Mont-Dieu",
+    "anciennesCommunes": [
+      {
+        "code": "08300",
+        "nom": "Le Mont-Dieu"
+      },
+      {
+        "code": "08439",
+        "nom": "Tannay"
+      }
+    ]
+  },
+  {
+    "code": "08490",
+    "nom": "Vouziers",
+    "anciennesCommunes": [
+      {
+        "code": "08443",
+        "nom": "Terron-sur-Aisne"
+      },
+      {
+        "code": "08490",
+        "nom": "Vouziers"
+      },
+      {
+        "code": "08493",
+        "nom": "Vrizy"
+      }
+    ]
+  },
+  {
+    "code": "08491",
+    "nom": "Vrigne aux Bois",
+    "anciennesCommunes": [
+      {
+        "code": "08072",
+        "nom": "Bosseval-et-Briancourt"
+      },
+      {
+        "code": "08491",
+        "nom": "Vrigne-aux-Bois"
+      }
+    ]
+  },
+  {
+    "code": "09056",
+    "nom": "Bézac",
+    "anciennesCommunes": [
+      {
+        "code": "09056",
+        "nom": "Bézac"
+      },
+      {
+        "code": "09255",
+        "nom": "Saint-Amans"
+      }
+    ]
+  },
+  {
+    "code": "09062",
+    "nom": "Bordes-Uchentein",
+    "anciennesCommunes": [
+      {
+        "code": "09062",
+        "nom": "Les Bordes-sur-Lez"
+      },
+      {
+        "code": "09317",
+        "nom": "Uchentein"
+      }
+    ]
+  },
+  {
+    "code": "09088",
+    "nom": "Caychax-et-Senconac",
+    "anciennesCommunes": [
+      {
+        "code": "09088",
+        "nom": "Caychax"
+      },
+      {
+        "code": "09287",
+        "nom": "Senconac"
+      }
+    ]
+  },
+  {
+    "code": "09296",
+    "nom": "Aulos-Sinsat",
+    "anciennesCommunes": [
+      {
+        "code": "09028",
+        "nom": "Aulos"
+      },
+      {
+        "code": "09296",
+        "nom": "Sinsat"
+      }
+    ]
+  },
+  {
+    "code": "09299",
+    "nom": "Soueix-Rogalle",
+    "anciennesCommunes": [
+      {
+        "code": "09299",
+        "nom": "Soueix-Rogalle"
+      }
+    ]
+  },
+  {
+    "code": "09334",
+    "nom": "Val-de-Sos",
+    "anciennesCommunes": [
+      {
+        "code": "09135",
+        "nom": "Goulier"
+      },
+      {
+        "code": "09286",
+        "nom": "Sem"
+      },
+      {
+        "code": "09302",
+        "nom": "Suc-et-Sentenac"
+      },
+      {
+        "code": "09334",
+        "nom": "Vicdessos"
+      }
+    ]
+  },
+  {
+    "code": "10003",
+    "nom": "Aix-Villemaur-Pâlis",
+    "anciennesCommunes": [
+      {
+        "code": "10003",
+        "nom": "Aix-en-Othe"
+      },
+      {
+        "code": "10277",
+        "nom": "Palis"
+      },
+      {
+        "code": "10415",
+        "nom": "Villemaur-sur-Vanne"
+      }
+    ]
+  },
+  {
+    "code": "11080",
+    "nom": "Val de Lambronne",
+    "anciennesCommunes": [
+      {
+        "code": "11080",
+        "nom": "Caudeval"
+      },
+      {
+        "code": "11171",
+        "nom": "Gueytes-et-Labastide"
+      }
+    ]
+  },
+  {
+    "code": "11131",
+    "nom": "Val-du-Faby",
+    "anciennesCommunes": [
+      {
+        "code": "11131",
+        "nom": "Fa"
+      },
+      {
+        "code": "11329",
+        "nom": "Rouvenac"
+      }
+    ]
+  },
+  {
+    "code": "11251",
+    "nom": "Val-de-Dagne",
+    "anciennesCommunes": [
+      {
+        "code": "11251",
+        "nom": "Montlaur"
+      },
+      {
+        "code": "11298",
+        "nom": "Pradelles-en-Val"
+      }
+    ]
+  },
+  {
+    "code": "11304",
+    "nom": "Quillan",
+    "anciennesCommunes": [
+      {
+        "code": "11050",
+        "nom": "Brenac"
+      },
+      {
+        "code": "11304",
+        "nom": "Quillan"
+      }
+    ]
+  },
+  {
+    "code": "11323",
+    "nom": "Roquetaillade-et-Conilhac",
+    "anciennesCommunes": [
+      {
+        "code": "11097",
+        "nom": "Conilhac-de-la-Montagne"
+      },
+      {
+        "code": "11323",
+        "nom": "Roquetaillade"
+      }
+    ]
+  },
+  {
+    "code": "12021",
+    "nom": "Le Bas Ségala",
+    "anciennesCommunes": [
+      {
+        "code": "12021",
+        "nom": "La Bastide-l'Évêque"
+      },
+      {
+        "code": "12245",
+        "nom": "Saint-Salvadou"
+      },
+      {
+        "code": "12285",
+        "nom": "Vabre-Tizac"
+      }
+    ]
+  },
+  {
+    "code": "12090",
+    "nom": "Druelle Balsac",
+    "anciennesCommunes": [
+      {
+        "code": "12020",
+        "nom": "Balsac"
+      },
+      {
+        "code": "12090",
+        "nom": "Druelle"
+      }
+    ]
+  },
+  {
+    "code": "12120",
+    "nom": "Laissac-Sévérac l'Église",
+    "anciennesCommunes": [
+      {
+        "code": "12120",
+        "nom": "Laissac"
+      },
+      {
+        "code": "12271",
+        "nom": "Sévérac-l'Église"
+      }
+    ]
+  },
+  {
+    "code": "12177",
+    "nom": "Palmas d'Aveyron",
+    "anciennesCommunes": [
+      {
+        "code": "12081",
+        "nom": "Coussergues"
+      },
+      {
+        "code": "12087",
+        "nom": "Cruéjouls"
+      },
+      {
+        "code": "12177",
+        "nom": "Palmas"
+      }
+    ]
+  },
+  {
+    "code": "12223",
+    "nom": "Argences en Aubrac",
+    "anciennesCommunes": [
+      {
+        "code": "12005",
+        "nom": "Alpuech"
+      },
+      {
+        "code": "12112",
+        "nom": "Graissac"
+      },
+      {
+        "code": "12117",
+        "nom": "Lacalm"
+      },
+      {
+        "code": "12223",
+        "nom": "Sainte-Geneviève-sur-Argence"
+      },
+      {
+        "code": "12279",
+        "nom": "La Terrisse"
+      },
+      {
+        "code": "12304",
+        "nom": "Vitrac-en-Viadène"
+      }
+    ]
+  },
+  {
+    "code": "12224",
+    "nom": "Saint Geniez d'Olt et d'Aubrac",
+    "anciennesCommunes": [
+      {
+        "code": "12014",
+        "nom": "Aurelle-Verlac"
+      },
+      {
+        "code": "12224",
+        "nom": "Saint-Geniez-d'Olt"
+      }
+    ]
+  },
+  {
+    "code": "12270",
+    "nom": "Sévérac d'Aveyron",
+    "anciennesCommunes": [
+      {
+        "code": "12040",
+        "nom": "Buzeins"
+      },
+      {
+        "code": "12123",
+        "nom": "Lapanouse"
+      },
+      {
+        "code": "12126",
+        "nom": "Lavernhe"
+      },
+      {
+        "code": "12196",
+        "nom": "Recoules-Prévinquières"
+      },
+      {
+        "code": "12270",
+        "nom": "Sévérac-le-Château"
+      }
+    ]
+  },
+  {
+    "code": "14005",
+    "nom": "Valambray",
+    "anciennesCommunes": [
+      {
+        "code": "14005",
+        "nom": "Airan"
+      },
+      {
+        "code": "14074",
+        "nom": "Billy"
+      },
+      {
+        "code": "14176",
+        "nom": "Conteville"
+      },
+      {
+        "code": "14268",
+        "nom": "Fierville-Bray"
+      },
+      {
+        "code": "14517",
+        "nom": "Poussy-la-Campagne"
+      }
+    ]
+  },
+  {
+    "code": "14014",
+    "nom": "Colomby-Anguerny",
+    "anciennesCommunes": [
+      {
+        "code": "14014",
+        "nom": "Anguerny"
+      },
+      {
+        "code": "14170",
+        "nom": "Colomby-sur-Thaon"
+      }
+    ]
+  },
+  {
+    "code": "14027",
+    "nom": "Les Monts d'Aunay",
+    "anciennesCommunes": [
+      {
+        "code": "14027",
+        "nom": "Aunay-sur-Odon"
+      },
+      {
+        "code": "14056",
+        "nom": "Bauquay"
+      },
+      {
+        "code": "14128",
+        "nom": "Campandré-Valcongrain"
+      },
+      {
+        "code": "14219",
+        "nom": "Danvou-la-Ferrière"
+      },
+      {
+        "code": "14477",
+        "nom": "Ondefontaine"
+      },
+      {
+        "code": "14508",
+        "nom": "Le Plessis-Grimoult"
+      },
+      {
+        "code": "14544",
+        "nom": "Roucamps"
+      }
+    ]
+  },
+  {
+    "code": "14035",
+    "nom": "Balleroy-sur-Drôme",
+    "anciennesCommunes": [
+      {
+        "code": "14035",
+        "nom": "Balleroy"
+      },
+      {
+        "code": "14727",
+        "nom": "Vaubadon"
+      }
+    ]
+  },
+  {
+    "code": "14037",
+    "nom": "Malherbe-sur-Ajon",
+    "anciennesCommunes": [
+      {
+        "code": "14037",
+        "nom": "Banneville-sur-Ajon"
+      },
+      {
+        "code": "14553",
+        "nom": "Saint-Agnan-le-Malherbe"
+      }
+    ]
+  },
+  {
+    "code": "14061",
+    "nom": "Souleuvre en Bocage",
+    "anciennesCommunes": [
+      {
+        "code": "14052",
+        "nom": "Beaulieu"
+      },
+      {
+        "code": "14061",
+        "nom": "Le Bény-Bocage"
+      },
+      {
+        "code": "14115",
+        "nom": "Bures-les-Monts"
+      },
+      {
+        "code": "14129",
+        "nom": "Campeaux"
+      },
+      {
+        "code": "14139",
+        "nom": "Carville"
+      },
+      {
+        "code": "14255",
+        "nom": "Étouvy"
+      },
+      {
+        "code": "14264",
+        "nom": "La Ferrière-Harang"
+      },
+      {
+        "code": "14317",
+        "nom": "La Graverie"
+      },
+      {
+        "code": "14395",
+        "nom": "Malloué"
+      },
+      {
+        "code": "14440",
+        "nom": "Montamy"
+      },
+      {
+        "code": "14441",
+        "nom": "Mont-Bertrand"
+      },
+      {
+        "code": "14443",
+        "nom": "Montchauvet"
+      },
+      {
+        "code": "14532",
+        "nom": "Le Reculey"
+      },
+      {
+        "code": "14573",
+        "nom": "Saint-Denis-Maisoncelles"
+      },
+      {
+        "code": "14618",
+        "nom": "Sainte-Marie-Laumont"
+      },
+      {
+        "code": "14629",
+        "nom": "Saint-Martin-des-Besaces"
+      },
+      {
+        "code": "14632",
+        "nom": "Saint-Martin-Don"
+      },
+      {
+        "code": "14636",
+        "nom": "Saint-Ouen-des-Besaces"
+      },
+      {
+        "code": "14655",
+        "nom": "Saint-Pierre-Tarentaine"
+      },
+      {
+        "code": "14704",
+        "nom": "Le Tourneur"
+      }
+    ]
+  },
+  {
+    "code": "14098",
+    "nom": "Thue et Mue",
+    "anciennesCommunes": [
+      {
+        "code": "14098",
+        "nom": "Bretteville-l'Orgueilleuse"
+      },
+      {
+        "code": "14109",
+        "nom": "Brouay"
+      },
+      {
+        "code": "14157",
+        "nom": "Cheux"
+      },
+      {
+        "code": "14423",
+        "nom": "Le Mesnil-Patry"
+      },
+      {
+        "code": "14525",
+        "nom": "Putot-en-Bessin"
+      },
+      {
+        "code": "14568",
+        "nom": "Sainte-Croix-Grand-Tonne"
+      }
+    ]
+  },
+  {
+    "code": "14118",
+    "nom": "Caen",
+    "anciennesCommunes": [
+      {
+        "code": "14118",
+        "nom": "Caen"
+      }
+    ]
+  },
+  {
+    "code": "14126",
+    "nom": "Cambremer",
+    "anciennesCommunes": [
+      {
+        "code": "14126",
+        "nom": "Cambremer"
+      },
+      {
+        "code": "14604",
+        "nom": "Saint-Laurent-du-Mont"
+      }
+    ]
+  },
+  {
+    "code": "14143",
+    "nom": "Caumont-sur-Aure",
+    "anciennesCommunes": [
+      {
+        "code": "14143",
+        "nom": "Caumont-l'Éventé"
+      },
+      {
+        "code": "14372",
+        "nom": "Livry"
+      },
+      {
+        "code": "14722",
+        "nom": "La Vacquerie"
+      }
+    ]
+  },
+  {
+    "code": "14150",
+    "nom": "Cesny-les-Sources",
+    "anciennesCommunes": [
+      {
+        "code": "14002",
+        "nom": "Acqueville"
+      },
+      {
+        "code": "14013",
+        "nom": "Angoville"
+      },
+      {
+        "code": "14150",
+        "nom": "Cesny-Bois-Halbout"
+      },
+      {
+        "code": "14505",
+        "nom": "Placy"
+      },
+      {
+        "code": "14703",
+        "nom": "Tournebu"
+      }
+    ]
+  },
+  {
+    "code": "14174",
+    "nom": "Condé-en-Normandie",
+    "anciennesCommunes": [
+      {
+        "code": "14152",
+        "nom": "La Chapelle-Engerbold"
+      },
+      {
+        "code": "14174",
+        "nom": "Condé-sur-Noireau"
+      },
+      {
+        "code": "14361",
+        "nom": "Lénault"
+      },
+      {
+        "code": "14523",
+        "nom": "Proussy"
+      },
+      {
+        "code": "14585",
+        "nom": "Saint-Germain-du-Crioult"
+      },
+      {
+        "code": "14653",
+        "nom": "Saint-Pierre-la-Vieille"
+      }
+    ]
+  },
+  {
+    "code": "14200",
+    "nom": "Creully sur Seulles",
+    "anciennesCommunes": [
+      {
+        "code": "14200",
+        "nom": "Creully"
+      },
+      {
+        "code": "14577",
+        "nom": "Saint-Gabriel-Brécy"
+      },
+      {
+        "code": "14757",
+        "nom": "Villiers-le-Sec"
+      }
+    ]
+  },
+  {
+    "code": "14281",
+    "nom": "Formigny La Bataille",
+    "anciennesCommunes": [
+      {
+        "code": "14004",
+        "nom": "Aignerville"
+      },
+      {
+        "code": "14235",
+        "nom": "Écrammeville"
+      },
+      {
+        "code": "14281",
+        "nom": "Formigny"
+      },
+      {
+        "code": "14382",
+        "nom": "Louvières"
+      }
+    ]
+  },
+  {
+    "code": "14342",
+    "nom": "Isigny-sur-Mer",
+    "anciennesCommunes": [
+      {
+        "code": "14142",
+        "nom": "Castilly"
+      },
+      {
+        "code": "14342",
+        "nom": "Isigny-sur-Mer"
+      },
+      {
+        "code": "14462",
+        "nom": "Neuilly-la-Forêt"
+      },
+      {
+        "code": "14481",
+        "nom": "Les Oubeaux"
+      },
+      {
+        "code": "14763",
+        "nom": "Vouilly"
+      }
+    ]
+  },
+  {
+    "code": "14347",
+    "nom": "Dialan sur Chaîne",
+    "anciennesCommunes": [
+      {
+        "code": "14347",
+        "nom": "Jurques"
+      },
+      {
+        "code": "14413",
+        "nom": "Le Mesnil-Auzouf"
+      }
+    ]
+  },
+  {
+    "code": "14349",
+    "nom": "Laize-Clinchamps",
+    "anciennesCommunes": [
+      {
+        "code": "14164",
+        "nom": "Clinchamps-sur-Orne"
+      },
+      {
+        "code": "14349",
+        "nom": "Laize-la-Ville"
+      }
+    ]
+  },
+  {
+    "code": "14355",
+    "nom": "Ponts sur Seulles",
+    "anciennesCommunes": [
+      {
+        "code": "14008",
+        "nom": "Amblie"
+      },
+      {
+        "code": "14355",
+        "nom": "Lantheuil"
+      },
+      {
+        "code": "14690",
+        "nom": "Tierceville"
+      }
+    ]
+  },
+  {
+    "code": "14357",
+    "nom": "Terres de Druance",
+    "anciennesCommunes": [
+      {
+        "code": "14357",
+        "nom": "Lassy"
+      },
+      {
+        "code": "14597",
+        "nom": "Saint-Jean-le-Blanc"
+      },
+      {
+        "code": "14662",
+        "nom": "Saint-Vigor-des-Mézerets"
+      }
+    ]
+  },
+  {
+    "code": "14371",
+    "nom": "Livarot-Pays-d'Auge",
+    "anciennesCommunes": [
+      {
+        "code": "14028",
+        "nom": "Auquainville"
+      },
+      {
+        "code": "14029",
+        "nom": "Les Autels-Saint-Bazile"
+      },
+      {
+        "code": "14058",
+        "nom": "Bellou"
+      },
+      {
+        "code": "14148",
+        "nom": "Cerqueux"
+      },
+      {
+        "code": "14155",
+        "nom": "Cheffreville-Tonnencourt"
+      },
+      {
+        "code": "14210",
+        "nom": "La Croupte"
+      },
+      {
+        "code": "14259",
+        "nom": "Familly"
+      },
+      {
+        "code": "14265",
+        "nom": "Fervaques"
+      },
+      {
+        "code": "14330",
+        "nom": "Heurtevent"
+      },
+      {
+        "code": "14371",
+        "nom": "Livarot"
+      },
+      {
+        "code": "14414",
+        "nom": "Le Mesnil-Bacley"
+      },
+      {
+        "code": "14418",
+        "nom": "Le Mesnil-Durand"
+      },
+      {
+        "code": "14420",
+        "nom": "Le Mesnil-Germain"
+      },
+      {
+        "code": "14429",
+        "nom": "Meulles"
+      },
+      {
+        "code": "14459",
+        "nom": "Les Moutiers-Hubert"
+      },
+      {
+        "code": "14471",
+        "nom": "Notre-Dame-de-Courson"
+      },
+      {
+        "code": "14518",
+        "nom": "Préaux-Saint-Sébastien"
+      },
+      {
+        "code": "14615",
+        "nom": "Sainte-Marguerite-des-Loges"
+      },
+      {
+        "code": "14633",
+        "nom": "Saint-Martin-du-Mesnil-Oury"
+      },
+      {
+        "code": "14634",
+        "nom": "Saint-Michel-de-Livet"
+      },
+      {
+        "code": "14638",
+        "nom": "Saint-Ouen-le-Houx"
+      },
+      {
+        "code": "14696",
+        "nom": "Tortisambert"
+      }
+    ]
+  },
+  {
+    "code": "14406",
+    "nom": "Moulins-en-Bessin",
+    "anciennesCommunes": [
+      {
+        "code": "14186",
+        "nom": "Coulombs"
+      },
+      {
+        "code": "14212",
+        "nom": "Cully"
+      },
+      {
+        "code": "14406",
+        "nom": "Martragny"
+      },
+      {
+        "code": "14548",
+        "nom": "Rucqueville"
+      }
+    ]
+  },
+  {
+    "code": "14408",
+    "nom": "Saint-Martin-de-May",
+    "anciennesCommunes": [
+      {
+        "code": "14408",
+        "nom": "May-sur-Orne"
+      },
+      {
+        "code": "14623",
+        "nom": "Saint-Martin-de-Fontenay"
+      }
+    ]
+  },
+  {
+    "code": "14410",
+    "nom": "Méry-Bissières-en-Auge",
+    "anciennesCommunes": [
+      {
+        "code": "14075",
+        "nom": "Bissières"
+      },
+      {
+        "code": "14410",
+        "nom": "Méry-Corbon"
+      }
+    ]
+  },
+  {
+    "code": "14431",
+    "nom": "Mézidon Vallée d'Auge",
+    "anciennesCommunes": [
+      {
+        "code": "14031",
+        "nom": "Les Authieux-Papion"
+      },
+      {
+        "code": "14189",
+        "nom": "Coupesarte"
+      },
+      {
+        "code": "14201",
+        "nom": "Crèvecœur-en-Auge"
+      },
+      {
+        "code": "14208",
+        "nom": "Croissanville"
+      },
+      {
+        "code": "14313",
+        "nom": "Grandchamp-le-Château"
+      },
+      {
+        "code": "14359",
+        "nom": "Lécaude"
+      },
+      {
+        "code": "14386",
+        "nom": "Magny-la-Campagne"
+      },
+      {
+        "code": "14387",
+        "nom": "Magny-le-Freule"
+      },
+      {
+        "code": "14422",
+        "nom": "Le Mesnil-Mauger"
+      },
+      {
+        "code": "14431",
+        "nom": "Mézidon-Canon"
+      },
+      {
+        "code": "14444",
+        "nom": "Monteille"
+      },
+      {
+        "code": "14493",
+        "nom": "Percy-en-Auge"
+      },
+      {
+        "code": "14600",
+        "nom": "Saint-Julien-le-Faucon"
+      },
+      {
+        "code": "14749",
+        "nom": "Vieux-Fumé"
+      }
+    ]
+  },
+  {
+    "code": "14456",
+    "nom": "Moult-Chicheboville",
+    "anciennesCommunes": [
+      {
+        "code": "14158",
+        "nom": "Chicheboville"
+      },
+      {
+        "code": "14456",
+        "nom": "Moult"
+      }
+    ]
+  },
+  {
+    "code": "14474",
+    "nom": "Notre-Dame-d'Estrées-Corbon",
+    "anciennesCommunes": [
+      {
+        "code": "14178",
+        "nom": "Corbon"
+      },
+      {
+        "code": "14474",
+        "nom": "Notre-Dame-d'Estrées"
+      }
+    ]
+  },
+  {
+    "code": "14475",
+    "nom": "Val d'Arry",
+    "anciennesCommunes": [
+      {
+        "code": "14373",
+        "nom": "Le Locheur"
+      },
+      {
+        "code": "14432",
+        "nom": "Missy"
+      },
+      {
+        "code": "14475",
+        "nom": "Noyers-Bocage"
+      },
+      {
+        "code": "14702",
+        "nom": "Tournay-sur-Odon"
+      }
+    ]
+  },
+  {
+    "code": "14514",
+    "nom": "Pont-l'Évêque",
+    "anciennesCommunes": [
+      {
+        "code": "14185",
+        "nom": "Coudray-Rabut"
+      },
+      {
+        "code": "14514",
+        "nom": "Pont-l'Évêque"
+      }
+    ]
+  },
+  {
+    "code": "14527",
+    "nom": "Belle Vie en Auge",
+    "anciennesCommunes": [
+      {
+        "code": "14527",
+        "nom": "Biéville-Quétiéville"
+      },
+      {
+        "code": "14608",
+        "nom": "Saint-Loup-de-Fribois"
+      }
+    ]
+  },
+  {
+    "code": "14538",
+    "nom": "Castine-en-Plaine",
+    "anciennesCommunes": [
+      {
+        "code": "14339",
+        "nom": "Hubert-Folie"
+      },
+      {
+        "code": "14538",
+        "nom": "Rocquancourt"
+      },
+      {
+        "code": "14691",
+        "nom": "Tilly-la-Campagne"
+      }
+    ]
+  },
+  {
+    "code": "14543",
+    "nom": "Rots",
+    "anciennesCommunes": [
+      {
+        "code": "14356",
+        "nom": "Lasson"
+      },
+      {
+        "code": "14543",
+        "nom": "Rots"
+      },
+      {
+        "code": "14670",
+        "nom": "Secqueville-en-Bessin"
+      }
+    ]
+  },
+  {
+    "code": "14554",
+    "nom": "Le Castelet",
+    "anciennesCommunes": [
+      {
+        "code": "14294",
+        "nom": "Garcelles-Secqueville"
+      },
+      {
+        "code": "14554",
+        "nom": "Saint-Aignan-de-Cramesnil"
+      }
+    ]
+  },
+  {
+    "code": "14570",
+    "nom": "Valorbiquet",
+    "anciennesCommunes": [
+      {
+        "code": "14154",
+        "nom": "La Chapelle-Yvon"
+      },
+      {
+        "code": "14570",
+        "nom": "Saint-Cyr-du-Ronceray"
+      },
+      {
+        "code": "14599",
+        "nom": "Saint-Julien-de-Mailloc"
+      },
+      {
+        "code": "14647",
+        "nom": "Saint-Pierre-de-Mailloc"
+      },
+      {
+        "code": "14693",
+        "nom": "Tordouet"
+      }
+    ]
+  },
+  {
+    "code": "14576",
+    "nom": "Val-de-Vie",
+    "anciennesCommunes": [
+      {
+        "code": "14105",
+        "nom": "La Brévière"
+      },
+      {
+        "code": "14153",
+        "nom": "La Chapelle-Haute-Grue"
+      },
+      {
+        "code": "14576",
+        "nom": "Sainte-Foy-de-Montgommery"
+      },
+      {
+        "code": "14583",
+        "nom": "Saint-Germain-de-Montgommery"
+      }
+    ]
+  },
+  {
+    "code": "14579",
+    "nom": "Seulline",
+    "anciennesCommunes": [
+      {
+        "code": "14073",
+        "nom": "La Bigne"
+      },
+      {
+        "code": "14188",
+        "nom": "Coulvain"
+      },
+      {
+        "code": "14579",
+        "nom": "Saint-Georges-d'Aunay"
+      }
+    ]
+  },
+  {
+    "code": "14591",
+    "nom": "Aure sur Mer",
+    "anciennesCommunes": [
+      {
+        "code": "14551",
+        "nom": "Russy"
+      },
+      {
+        "code": "14591",
+        "nom": "Sainte-Honorine-des-Pertes"
+      }
+    ]
+  },
+  {
+    "code": "14621",
+    "nom": "Saint-Martin-de-Bienfaite-la-Cressonnière",
+    "anciennesCommunes": [
+      {
+        "code": "14621",
+        "nom": "Saint-Martin-de-Bienfaite-la-Cressonnière"
+      }
+    ]
+  },
+  {
+    "code": "14654",
+    "nom": "Saint-Pierre-en-Auge",
+    "anciennesCommunes": [
+      {
+        "code": "14081",
+        "nom": "Boissey"
+      },
+      {
+        "code": "14099",
+        "nom": "Bretteville-sur-Dives"
+      },
+      {
+        "code": "14331",
+        "nom": "Hiéville"
+      },
+      {
+        "code": "14433",
+        "nom": "Mittois"
+      },
+      {
+        "code": "14450",
+        "nom": "Montviette"
+      },
+      {
+        "code": "14472",
+        "nom": "L'Oudon"
+      },
+      {
+        "code": "14489",
+        "nom": "Ouville-la-Bien-Tournée"
+      },
+      {
+        "code": "14580",
+        "nom": "Saint-Georges-en-Auge"
+      },
+      {
+        "code": "14616",
+        "nom": "Sainte-Marguerite-de-Viette"
+      },
+      {
+        "code": "14654",
+        "nom": "Saint-Pierre-sur-Dives"
+      },
+      {
+        "code": "14688",
+        "nom": "Thiéville"
+      },
+      {
+        "code": "14729",
+        "nom": "Vaudeloges"
+      },
+      {
+        "code": "14750",
+        "nom": "Vieux-Pont-en-Auge"
+      }
+    ]
+  },
+  {
+    "code": "14658",
+    "nom": "Noues de Sienne",
+    "anciennesCommunes": [
+      {
+        "code": "14151",
+        "nom": "Champ-du-Boult"
+      },
+      {
+        "code": "14192",
+        "nom": "Courson"
+      },
+      {
+        "code": "14279",
+        "nom": "Fontenermont"
+      },
+      {
+        "code": "14296",
+        "nom": "Le Gast"
+      },
+      {
+        "code": "14415",
+        "nom": "Le Mesnil-Benoist"
+      },
+      {
+        "code": "14416",
+        "nom": "Le Mesnil-Caussois"
+      },
+      {
+        "code": "14417",
+        "nom": "Mesnil-Clinchamps"
+      },
+      {
+        "code": "14611",
+        "nom": "Saint-Manvieu-Bocage"
+      },
+      {
+        "code": "14658",
+        "nom": "Saint-Sever-Calvados"
+      },
+      {
+        "code": "14671",
+        "nom": "Sept-Frères"
+      }
+    ]
+  },
+  {
+    "code": "14672",
+    "nom": "Val de Drôme",
+    "anciennesCommunes": [
+      {
+        "code": "14217",
+        "nom": "Dampierre"
+      },
+      {
+        "code": "14350",
+        "nom": "La Lande-sur-Drôme"
+      },
+      {
+        "code": "14596",
+        "nom": "Saint-Jean-des-Essartiers"
+      },
+      {
+        "code": "14672",
+        "nom": "Sept-Vents"
+      }
+    ]
+  },
+  {
+    "code": "14689",
+    "nom": "Thury-Harcourt-le-Hom",
+    "anciennesCommunes": [
+      {
+        "code": "14144",
+        "nom": "Caumont-sur-Orne"
+      },
+      {
+        "code": "14213",
+        "nom": "Curcy-sur-Orne"
+      },
+      {
+        "code": "14324",
+        "nom": "Hamars"
+      },
+      {
+        "code": "14628",
+        "nom": "Saint-Martin-de-Sallen"
+      },
+      {
+        "code": "14689",
+        "nom": "Thury-Harcourt"
+      }
+    ]
+  },
+  {
+    "code": "14712",
+    "nom": "Troarn",
+    "anciennesCommunes": [
+      {
+        "code": "14666",
+        "nom": "Sannerville"
+      },
+      {
+        "code": "14712",
+        "nom": "Troarn"
+      }
+    ]
+  },
+  {
+    "code": "14713",
+    "nom": "Montillières-sur-Orne",
+    "anciennesCommunes": [
+      {
+        "code": "14307",
+        "nom": "Goupillières"
+      },
+      {
+        "code": "14713",
+        "nom": "Trois-Monts"
+      }
+    ]
+  },
+  {
+    "code": "14726",
+    "nom": "Valdallière",
+    "anciennesCommunes": [
+      {
+        "code": "14065",
+        "nom": "Bernières-le-Patry"
+      },
+      {
+        "code": "14113",
+        "nom": "Burcy"
+      },
+      {
+        "code": "14156",
+        "nom": "Chênedollé"
+      },
+      {
+        "code": "14222",
+        "nom": "Le Désert"
+      },
+      {
+        "code": "14253",
+        "nom": "Estry"
+      },
+      {
+        "code": "14442",
+        "nom": "Montchamp"
+      },
+      {
+        "code": "14503",
+        "nom": "Pierres"
+      },
+      {
+        "code": "14521",
+        "nom": "Presles"
+      },
+      {
+        "code": "14539",
+        "nom": "La Rocque"
+      },
+      {
+        "code": "14549",
+        "nom": "Rully"
+      },
+      {
+        "code": "14564",
+        "nom": "Saint-Charles-de-Percy"
+      },
+      {
+        "code": "14686",
+        "nom": "Le Theil-Bocage"
+      },
+      {
+        "code": "14726",
+        "nom": "Vassy"
+      },
+      {
+        "code": "14746",
+        "nom": "Viessoix"
+      }
+    ]
+  },
+  {
+    "code": "14740",
+    "nom": "La Vespière-Friardel",
+    "anciennesCommunes": [
+      {
+        "code": "14292",
+        "nom": "Friardel"
+      },
+      {
+        "code": "14740",
+        "nom": "La Vespière"
+      }
+    ]
+  },
+  {
+    "code": "14743",
+    "nom": "Victot-en-Auge",
+    "anciennesCommunes": [
+      {
+        "code": "14300",
+        "nom": "Gerrots"
+      },
+      {
+        "code": "14743",
+        "nom": "Victot-Pontfol"
+      }
+    ]
+  },
+  {
+    "code": "14762",
+    "nom": "Vire Normandie",
+    "anciennesCommunes": [
+      {
+        "code": "14187",
+        "nom": "Coulonces"
+      },
+      {
+        "code": "14388",
+        "nom": "Maisoncelles-la-Jourdan"
+      },
+      {
+        "code": "14545",
+        "nom": "Roullours"
+      },
+      {
+        "code": "14584",
+        "nom": "Saint-Germain-de-Tallevende-la-Lande-Vaumont"
+      },
+      {
+        "code": "14717",
+        "nom": "Truttemer-le-Grand"
+      },
+      {
+        "code": "14718",
+        "nom": "Truttemer-le-Petit"
+      },
+      {
+        "code": "14730",
+        "nom": "Vaudry"
+      },
+      {
+        "code": "14762",
+        "nom": "Vire"
+      }
+    ]
+  },
+  {
+    "code": "15027",
+    "nom": "Puycapel",
+    "anciennesCommunes": [
+      {
+        "code": "15027",
+        "nom": "Calvinet"
+      },
+      {
+        "code": "15136",
+        "nom": "Mourjou"
+      }
+    ]
+  },
+  {
+    "code": "15108",
+    "nom": "Val d'Arcomie",
+    "anciennesCommunes": [
+      {
+        "code": "15068",
+        "nom": "Faverolles"
+      },
+      {
+        "code": "15108",
+        "nom": "Loubaresse"
+      },
+      {
+        "code": "15195",
+        "nom": "Saint-Just"
+      },
+      {
+        "code": "15197",
+        "nom": "Saint-Marc"
+      }
+    ]
+  },
+  {
+    "code": "15138",
+    "nom": "Murat",
+    "anciennesCommunes": [
+      {
+        "code": "15044",
+        "nom": "Chastel-sur-Murat"
+      },
+      {
+        "code": "15138",
+        "nom": "Murat"
+      }
+    ]
+  },
+  {
+    "code": "15142",
+    "nom": "Neuvéglise-sur-Truyère",
+    "anciennesCommunes": [
+      {
+        "code": "15099",
+        "nom": "Lavastrie"
+      },
+      {
+        "code": "15142",
+        "nom": "Neuvéglise"
+      },
+      {
+        "code": "15145",
+        "nom": "Oradour"
+      },
+      {
+        "code": "15227",
+        "nom": "Sériers"
+      }
+    ]
+  },
+  {
+    "code": "15181",
+    "nom": "Saint-Constant-Fournoulès",
+    "anciennesCommunes": [
+      {
+        "code": "15071",
+        "nom": "Fournoulès"
+      },
+      {
+        "code": "15181",
+        "nom": "Saint-Constant"
+      }
+    ]
+  },
+  {
+    "code": "15268",
+    "nom": "Le Rouget-Pers",
+    "anciennesCommunes": [
+      {
+        "code": "15150",
+        "nom": "Pers"
+      },
+      {
+        "code": "15268",
+        "nom": "Le Rouget"
+      }
+    ]
+  },
+  {
+    "code": "16005",
+    "nom": "Aigre",
+    "anciennesCommunes": [
+      {
+        "code": "16005",
+        "nom": "Aigre"
+      },
+      {
+        "code": "16411",
+        "nom": "Villejésus"
+      }
+    ]
+  },
+  {
+    "code": "16023",
+    "nom": "Aunac-sur-Charente",
+    "anciennesCommunes": [
+      {
+        "code": "16023",
+        "nom": "Aunac"
+      },
+      {
+        "code": "16033",
+        "nom": "Bayers"
+      },
+      {
+        "code": "16094",
+        "nom": "Chenommet"
+      },
+      {
+        "code": "16238",
+        "nom": "Moutonneau"
+      }
+    ]
+  },
+  {
+    "code": "16046",
+    "nom": "Coteaux-du-Blanzacais",
+    "anciennesCommunes": [
+      {
+        "code": "16046",
+        "nom": "Blanzac-Porcheresse"
+      },
+      {
+        "code": "16115",
+        "nom": "Cressac-Saint-Genis"
+      },
+      {
+        "code": "16332",
+        "nom": "Saint-Léger"
+      }
+    ]
+  },
+  {
+    "code": "16082",
+    "nom": "Boisné-La Tude",
+    "anciennesCommunes": [
+      {
+        "code": "16082",
+        "nom": "Charmant"
+      },
+      {
+        "code": "16092",
+        "nom": "Chavenat"
+      },
+      {
+        "code": "16172",
+        "nom": "Juillaguet"
+      }
+    ]
+  },
+  {
+    "code": "16097",
+    "nom": "Val-de-Cognac",
+    "anciennesCommunes": [
+      {
+        "code": "16097",
+        "nom": "Cherves-Richemont"
+      },
+      {
+        "code": "16355",
+        "nom": "Saint-Sulpice-de-Cognac"
+      }
+    ]
+  },
+  {
+    "code": "16106",
+    "nom": "Confolens",
+    "anciennesCommunes": [
+      {
+        "code": "16106",
+        "nom": "Confolens"
+      },
+      {
+        "code": "16322",
+        "nom": "Saint-Germain-de-Confolens"
+      }
+    ]
+  },
+  {
+    "code": "16110",
+    "nom": "Courcôme",
+    "anciennesCommunes": [
+      {
+        "code": "16110",
+        "nom": "Courcôme"
+      },
+      {
+        "code": "16391",
+        "nom": "Tuzie"
+      },
+      {
+        "code": "16410",
+        "nom": "Villegats"
+      }
+    ]
+  },
+  {
+    "code": "16148",
+    "nom": "Genac-Bignac",
+    "anciennesCommunes": [
+      {
+        "code": "16043",
+        "nom": "Bignac"
+      },
+      {
+        "code": "16148",
+        "nom": "Genac"
+      }
+    ]
+  },
+  {
+    "code": "16153",
+    "nom": "Mainxe-Gondeville",
+    "anciennesCommunes": [
+      {
+        "code": "16153",
+        "nom": "Gondeville"
+      },
+      {
+        "code": "16202",
+        "nom": "Mainxe"
+      }
+    ]
+  },
+  {
+    "code": "16175",
+    "nom": "Val des Vignes",
+    "anciennesCommunes": [
+      {
+        "code": "16021",
+        "nom": "Aubeville"
+      },
+      {
+        "code": "16175",
+        "nom": "Jurignac"
+      },
+      {
+        "code": "16201",
+        "nom": "Mainfonds"
+      },
+      {
+        "code": "16257",
+        "nom": "Péreuil"
+      }
+    ]
+  },
+  {
+    "code": "16186",
+    "nom": "Lignières-Ambleville",
+    "anciennesCommunes": [
+      {
+        "code": "16010",
+        "nom": "Ambleville"
+      },
+      {
+        "code": "16186",
+        "nom": "Lignières-Sonneville"
+      }
+    ]
+  },
+  {
+    "code": "16192",
+    "nom": "Terres-de-Haute-Charente",
+    "anciennesCommunes": [
+      {
+        "code": "16149",
+        "nom": "Genouillac"
+      },
+      {
+        "code": "16192",
+        "nom": "Roumazières-Loubert"
+      },
+      {
+        "code": "16214",
+        "nom": "Mazières"
+      },
+      {
+        "code": "16259",
+        "nom": "La Péruse"
+      },
+      {
+        "code": "16376",
+        "nom": "Suris"
+      }
+    ]
+  },
+  {
+    "code": "16198",
+    "nom": "Magnac-lès-Gardes",
+    "anciennesCommunes": [
+      {
+        "code": "16147",
+        "nom": "Gardes-le-Pontaroux"
+      },
+      {
+        "code": "16198",
+        "nom": "Magnac-Lavalette-Villars"
+      }
+    ]
+  },
+  {
+    "code": "16204",
+    "nom": "Bellevigne",
+    "anciennesCommunes": [
+      {
+        "code": "16129",
+        "nom": "Éraville"
+      },
+      {
+        "code": "16204",
+        "nom": "Malaville"
+      },
+      {
+        "code": "16247",
+        "nom": "Nonaville"
+      },
+      {
+        "code": "16386",
+        "nom": "Touzac"
+      },
+      {
+        "code": "16417",
+        "nom": "Viville"
+      }
+    ]
+  },
+  {
+    "code": "16206",
+    "nom": "Mansle-les-Fontaines",
+    "anciennesCommunes": [
+      {
+        "code": "16140",
+        "nom": "Fontclaireau"
+      },
+      {
+        "code": "16206",
+        "nom": "Mansle"
+      }
+    ]
+  },
+  {
+    "code": "16224",
+    "nom": "Montmérac",
+    "anciennesCommunes": [
+      {
+        "code": "16179",
+        "nom": "Lamérac"
+      },
+      {
+        "code": "16224",
+        "nom": "Montchaude"
+      }
+    ]
+  },
+  {
+    "code": "16230",
+    "nom": "Montmoreau",
+    "anciennesCommunes": [
+      {
+        "code": "16004",
+        "nom": "Aignes-et-Puypéroux"
+      },
+      {
+        "code": "16230",
+        "nom": "Montmoreau-Saint-Cybard"
+      },
+      {
+        "code": "16294",
+        "nom": "Saint-Amant-de-Montmoreau"
+      },
+      {
+        "code": "16314",
+        "nom": "Saint-Eutrope"
+      },
+      {
+        "code": "16328",
+        "nom": "Saint-Laurent-de-Belzagot"
+      }
+    ]
+  },
+  {
+    "code": "16233",
+    "nom": "Mosnac-Saint-Simeux",
+    "anciennesCommunes": [
+      {
+        "code": "16233",
+        "nom": "Mosnac"
+      },
+      {
+        "code": "16351",
+        "nom": "Saint-Simeux"
+      }
+    ]
+  },
+  {
+    "code": "16242",
+    "nom": "Nanteuil-en-Vallée",
+    "anciennesCommunes": [
+      {
+        "code": "16242",
+        "nom": "Nanteuil-en-Vallée"
+      }
+    ]
+  },
+  {
+    "code": "16281",
+    "nom": "La Rochefoucauld-en-Angoumois",
+    "anciennesCommunes": [
+      {
+        "code": "16281",
+        "nom": "La Rochefoucauld"
+      },
+      {
+        "code": "16344",
+        "nom": "Saint-Projet-Saint-Constant"
+      }
+    ]
+  },
+  {
+    "code": "16286",
+    "nom": "Rouillac",
+    "anciennesCommunes": [
+      {
+        "code": "16156",
+        "nom": "Gourville"
+      },
+      {
+        "code": "16262",
+        "nom": "Plaizac"
+      },
+      {
+        "code": "16286",
+        "nom": "Rouillac"
+      },
+      {
+        "code": "16371",
+        "nom": "Sonneville"
+      }
+    ]
+  },
+  {
+    "code": "16300",
+    "nom": "Val-de-Bonnieure",
+    "anciennesCommunes": [
+      {
+        "code": "16296",
+        "nom": "Saint-Amant-de-Bonnieure"
+      },
+      {
+        "code": "16300",
+        "nom": "Saint-Angeau"
+      },
+      {
+        "code": "16309",
+        "nom": "Sainte-Colombe"
+      }
+    ]
+  },
+  {
+    "code": "16339",
+    "nom": "Val-d'Auge",
+    "anciennesCommunes": [
+      {
+        "code": "16017",
+        "nom": "Anville"
+      },
+      {
+        "code": "16051",
+        "nom": "Bonneville"
+      },
+      {
+        "code": "16228",
+        "nom": "Montigné"
+      },
+      {
+        "code": "16339",
+        "nom": "Auge-Saint-Médard"
+      }
+    ]
+  },
+  {
+    "code": "16393",
+    "nom": "La Boixe",
+    "anciennesCommunes": [
+      {
+        "code": "16226",
+        "nom": "Montignac-Charente"
+      },
+      {
+        "code": "16393",
+        "nom": "Vars"
+      }
+    ]
+  },
+  {
+    "code": "16406",
+    "nom": "Moulins-sur-Tardoire",
+    "anciennesCommunes": [
+      {
+        "code": "16274",
+        "nom": "Rancogne"
+      },
+      {
+        "code": "16406",
+        "nom": "Vilhonneur"
+      }
+    ]
+  },
+  {
+    "code": "17013",
+    "nom": "Antezant-la-Chapelle",
+    "anciennesCommunes": [
+      {
+        "code": "17013",
+        "nom": "Antezant-la-Chapelle"
+      }
+    ]
+  },
+  {
+    "code": "17160",
+    "nom": "Floirac",
+    "anciennesCommunes": [
+      {
+        "code": "17160",
+        "nom": "Floirac"
+      },
+      {
+        "code": "17392",
+        "nom": "Saint-Romain-sur-Gironde"
+      }
+    ]
+  },
+  {
+    "code": "17219",
+    "nom": "Marennes-Hiers-Brouage",
+    "anciennesCommunes": [
+      {
+        "code": "17189",
+        "nom": "Hiers-Brouage"
+      },
+      {
+        "code": "17219",
+        "nom": "Marennes"
+      }
+    ]
+  },
+  {
+    "code": "17268",
+    "nom": "Rives-de-Boutonne",
+    "anciennesCommunes": [
+      {
+        "code": "17268",
+        "nom": "Nuaillé-sur-Boutonne"
+      },
+      {
+        "code": "17334",
+        "nom": "Saint-Georges-de-Longuepierre"
+      }
+    ]
+  },
+  {
+    "code": "17277",
+    "nom": "Essouvert",
+    "anciennesCommunes": [
+      {
+        "code": "17040",
+        "nom": "La Benâte"
+      },
+      {
+        "code": "17277",
+        "nom": "Saint-Denis-du-Pin"
+      }
+    ]
+  },
+  {
+    "code": "17295",
+    "nom": "Réaux sur Trèfle",
+    "anciennesCommunes": [
+      {
+        "code": "17238",
+        "nom": "Moings"
+      },
+      {
+        "code": "17295",
+        "nom": "Réaux"
+      },
+      {
+        "code": "17371",
+        "nom": "Saint-Maurice-de-Tavernole"
+      }
+    ]
+  },
+  {
+    "code": "17340",
+    "nom": "Saint-Pierre-La-Noue",
+    "anciennesCommunes": [
+      {
+        "code": "17272",
+        "nom": "Péré"
+      },
+      {
+        "code": "17340",
+        "nom": "Saint-Germain-de-Marencennes"
+      }
+    ]
+  },
+  {
+    "code": "17344",
+    "nom": "Saint-Hilaire-de-Villefranche",
+    "anciennesCommunes": [
+      {
+        "code": "17169",
+        "nom": "La Frédière"
+      },
+      {
+        "code": "17344",
+        "nom": "Saint-Hilaire-de-Villefranche"
+      }
+    ]
+  },
+  {
+    "code": "17457",
+    "nom": "La Devise",
+    "anciennesCommunes": [
+      {
+        "code": "17103",
+        "nom": "Chervettes"
+      },
+      {
+        "code": "17352",
+        "nom": "Saint-Laurent-de-la-Barrière"
+      },
+      {
+        "code": "17457",
+        "nom": "Vandré"
+      }
+    ]
+  },
+  {
+    "code": "18023",
+    "nom": "Baugy",
+    "anciennesCommunes": [
+      {
+        "code": "18023",
+        "nom": "Baugy"
+      },
+      {
+        "code": "18123",
+        "nom": "Laverdines"
+      },
+      {
+        "code": "18239",
+        "nom": "Saligny-le-Vif"
+      }
+    ]
+  },
+  {
+    "code": "18073",
+    "nom": "Corquoy",
+    "anciennesCommunes": [
+      {
+        "code": "18073",
+        "nom": "Corquoy"
+      },
+      {
+        "code": "18222",
+        "nom": "Sainte-Lunaise"
+      }
+    ]
+  },
+  {
+    "code": "18173",
+    "nom": "Osmery",
+    "anciennesCommunes": [
+      {
+        "code": "18131",
+        "nom": "Lugny-Bourbonnais"
+      },
+      {
+        "code": "18173",
+        "nom": "Osmery"
+      }
+    ]
+  },
+  {
+    "code": "19010",
+    "nom": "Argentat-sur-Dordogne",
+    "anciennesCommunes": [
+      {
+        "code": "19010",
+        "nom": "Argentat"
+      },
+      {
+        "code": "19183",
+        "nom": "Saint-Bazile-de-la-Roche"
+      }
+    ]
+  },
+  {
+    "code": "19019",
+    "nom": "Beaulieu-sur-Dordogne",
+    "anciennesCommunes": [
+      {
+        "code": "19019",
+        "nom": "Beaulieu-sur-Dordogne"
+      },
+      {
+        "code": "19032",
+        "nom": "Brivezac"
+      }
+    ]
+  },
+  {
+    "code": "19098",
+    "nom": "Lagarde-Marc-la-Tour",
+    "anciennesCommunes": [
+      {
+        "code": "19098",
+        "nom": "Lagarde-Enval"
+      },
+      {
+        "code": "19127",
+        "nom": "Marc-la-Tour"
+      }
+    ]
+  },
+  {
+    "code": "19101",
+    "nom": "Laguenne-sur-Avalouze",
+    "anciennesCommunes": [
+      {
+        "code": "19101",
+        "nom": "Laguenne"
+      },
+      {
+        "code": "19185",
+        "nom": "Saint-Bonnet-Avalouze"
+      }
+    ]
+  },
+  {
+    "code": "19123",
+    "nom": "Malemort",
+    "anciennesCommunes": [
+      {
+        "code": "19123",
+        "nom": "Malemort-sur-Corrèze"
+      },
+      {
+        "code": "19282",
+        "nom": "Venarsal"
+      }
+    ]
+  },
+  {
+    "code": "19143",
+    "nom": "Montaignac-sur-Doustre",
+    "anciennesCommunes": [
+      {
+        "code": "19092",
+        "nom": "Le Jardin"
+      },
+      {
+        "code": "19143",
+        "nom": "Montaignac-Saint-Hippolyte"
+      }
+    ]
+  },
+  {
+    "code": "19248",
+    "nom": "Les Trois-Saints",
+    "anciennesCommunes": [
+      {
+        "code": "19223",
+        "nom": "Saint-Martin-Sepert"
+      },
+      {
+        "code": "19230",
+        "nom": "Saint-Pardoux-Corbier"
+      },
+      {
+        "code": "19248",
+        "nom": "Saint-Ybard"
+      }
+    ]
+  },
+  {
+    "code": "19252",
+    "nom": "Sarroux - Saint Julien",
+    "anciennesCommunes": [
+      {
+        "code": "19218",
+        "nom": "Saint-Julien-près-Bort"
+      },
+      {
+        "code": "19252",
+        "nom": "Sarroux"
+      }
+    ]
+  },
+  {
+    "code": "21178",
+    "nom": "Valforêt",
+    "anciennesCommunes": [
+      {
+        "code": "21178",
+        "nom": "Clémencey"
+      },
+      {
+        "code": "21513",
+        "nom": "Quemigny-Poisot"
+      }
+    ]
+  },
+  {
+    "code": "21183",
+    "nom": "Collonges-et-Premières",
+    "anciennesCommunes": [
+      {
+        "code": "21183",
+        "nom": "Collonges-lès-Premières"
+      },
+      {
+        "code": "21507",
+        "nom": "Premières"
+      }
+    ]
+  },
+  {
+    "code": "21195",
+    "nom": "Cormot-Vauchignon",
+    "anciennesCommunes": [
+      {
+        "code": "21195",
+        "nom": "Cormot-le-Grand"
+      },
+      {
+        "code": "21658",
+        "nom": "Vauchignon"
+      }
+    ]
+  },
+  {
+    "code": "21272",
+    "nom": "Le Val-Larrey",
+    "anciennesCommunes": [
+      {
+        "code": "21073",
+        "nom": "Bierre-lès-Semur"
+      },
+      {
+        "code": "21272",
+        "nom": "Flée"
+      }
+    ]
+  },
+  {
+    "code": "21327",
+    "nom": "Val-Mont",
+    "anciennesCommunes": [
+      {
+        "code": "21318",
+        "nom": "Ivry-en-Montagne"
+      },
+      {
+        "code": "21327",
+        "nom": "Jours-en-Vaux"
+      }
+    ]
+  },
+  {
+    "code": "21352",
+    "nom": "Longeault-Pluvault",
+    "anciennesCommunes": [
+      {
+        "code": "21352",
+        "nom": "Longeault"
+      },
+      {
+        "code": "21486",
+        "nom": "Pluvault"
+      }
+    ]
+  },
+  {
+    "code": "21452",
+    "nom": "Neuilly-Crimolois",
+    "anciennesCommunes": [
+      {
+        "code": "21213",
+        "nom": "Crimolois"
+      },
+      {
+        "code": "21452",
+        "nom": "Neuilly-lès-Dijon"
+      }
+    ]
+  },
+  {
+    "code": "21623",
+    "nom": "Tart",
+    "anciennesCommunes": [
+      {
+        "code": "21621",
+        "nom": "Tart-l'Abbaye"
+      },
+      {
+        "code": "21623",
+        "nom": "Tart-le-Haut"
+      }
+    ]
+  },
+  {
+    "code": "22046",
+    "nom": "Le Mené",
+    "anciennesCommunes": [
+      {
+        "code": "22046",
+        "nom": "Collinée"
+      },
+      {
+        "code": "22066",
+        "nom": "Le Gouray"
+      },
+      {
+        "code": "22102",
+        "nom": "Langourla"
+      },
+      {
+        "code": "22191",
+        "nom": "Plessala"
+      },
+      {
+        "code": "22292",
+        "nom": "Saint-Gilles-du-Mené"
+      },
+      {
+        "code": "22297",
+        "nom": "Saint-Gouéno"
+      },
+      {
+        "code": "22303",
+        "nom": "Saint-Jacut-du-Mené"
+      }
+    ]
+  },
+  {
+    "code": "22050",
+    "nom": "Dinan",
+    "anciennesCommunes": [
+      {
+        "code": "22050",
+        "nom": "Dinan"
+      },
+      {
+        "code": "22123",
+        "nom": "Léhon"
+      }
+    ]
+  },
+  {
+    "code": "22055",
+    "nom": "Binic-Étables-sur-Mer",
+    "anciennesCommunes": [
+      {
+        "code": "22007",
+        "nom": "Binic"
+      },
+      {
+        "code": "22055",
+        "nom": "Étables-sur-Mer"
+      }
+    ]
+  },
+  {
+    "code": "22084",
+    "nom": "Jugon-les-Lacs",
+    "anciennesCommunes": [
+      {
+        "code": "22051",
+        "nom": "Dolo"
+      },
+      {
+        "code": "22084",
+        "nom": "Jugon-les-Lacs"
+      }
+    ]
+  },
+  {
+    "code": "22093",
+    "nom": "Lamballe-Armor",
+    "anciennesCommunes": [
+      {
+        "code": "22093",
+        "nom": "Lamballe"
+      },
+      {
+        "code": "22151",
+        "nom": "Meslin"
+      },
+      {
+        "code": "22154",
+        "nom": "Morieux"
+      },
+      {
+        "code": "22173",
+        "nom": "Planguenoual"
+      }
+    ]
+  },
+  {
+    "code": "22107",
+    "nom": "Bon Repos sur Blavet",
+    "anciennesCommunes": [
+      {
+        "code": "22107",
+        "nom": "Laniscat"
+      },
+      {
+        "code": "22167",
+        "nom": "Perret"
+      },
+      {
+        "code": "22290",
+        "nom": "Saint-Gelven"
+      }
+    ]
+  },
+  {
+    "code": "22118",
+    "nom": "Lanvallay",
+    "anciennesCommunes": [
+      {
+        "code": "22118",
+        "nom": "Lanvallay"
+      }
+    ]
+  },
+  {
+    "code": "22147",
+    "nom": "Merdrignac",
+    "anciennesCommunes": [
+      {
+        "code": "22147",
+        "nom": "Merdrignac"
+      },
+      {
+        "code": "22309",
+        "nom": "Saint-Launeuc"
+      }
+    ]
+  },
+  {
+    "code": "22158",
+    "nom": "Guerlédan",
+    "anciennesCommunes": [
+      {
+        "code": "22158",
+        "nom": "Mûr-de-Bretagne"
+      },
+      {
+        "code": "22298",
+        "nom": "Saint-Guen"
+      }
+    ]
+  },
+  {
+    "code": "22183",
+    "nom": "Plémet",
+    "anciennesCommunes": [
+      {
+        "code": "22058",
+        "nom": "La Ferrière"
+      },
+      {
+        "code": "22183",
+        "nom": "Plémet"
+      }
+    ]
+  },
+  {
+    "code": "22190",
+    "nom": "Pleslin-Trigavou",
+    "anciennesCommunes": [
+      {
+        "code": "22190",
+        "nom": "Pleslin-Trigavou"
+      }
+    ]
+  },
+  {
+    "code": "22203",
+    "nom": "Plœuc-L'Hermitage",
+    "anciennesCommunes": [
+      {
+        "code": "22080",
+        "nom": "L'Hermitage-Lorge"
+      },
+      {
+        "code": "22203",
+        "nom": "Plœuc-sur-Lié"
+      }
+    ]
+  },
+  {
+    "code": "22206",
+    "nom": "Châtelaudren-Plouagat",
+    "anciennesCommunes": [
+      {
+        "code": "22038",
+        "nom": "Châtelaudren"
+      },
+      {
+        "code": "22206",
+        "nom": "Plouagat"
+      }
+    ]
+  },
+  {
+    "code": "22209",
+    "nom": "Beaussais-sur-Mer",
+    "anciennesCommunes": [
+      {
+        "code": "22192",
+        "nom": "Plessix-Balisson"
+      },
+      {
+        "code": "22209",
+        "nom": "Ploubalay"
+      },
+      {
+        "code": "22357",
+        "nom": "Trégon"
+      }
+    ]
+  },
+  {
+    "code": "22219",
+    "nom": "Plouguenast-Langast",
+    "anciennesCommunes": [
+      {
+        "code": "22100",
+        "nom": "Langast"
+      },
+      {
+        "code": "22219",
+        "nom": "Plouguenast"
+      }
+    ]
+  },
+  {
+    "code": "22237",
+    "nom": "Val-d'Arguenon",
+    "anciennesCommunes": [
+      {
+        "code": "22200",
+        "nom": "Pléven"
+      },
+      {
+        "code": "22237",
+        "nom": "Pluduno"
+      }
+    ]
+  },
+  {
+    "code": "22241",
+    "nom": "Plumieux",
+    "anciennesCommunes": [
+      {
+        "code": "22027",
+        "nom": "Le Cambout"
+      },
+      {
+        "code": "22043",
+        "nom": "Coëtlogon"
+      },
+      {
+        "code": "22241",
+        "nom": "Plumieux"
+      }
+    ]
+  },
+  {
+    "code": "22251",
+    "nom": "Pordic",
+    "anciennesCommunes": [
+      {
+        "code": "22251",
+        "nom": "Pordic"
+      },
+      {
+        "code": "22367",
+        "nom": "Tréméloir"
+      }
+    ]
+  },
+  {
+    "code": "22264",
+    "nom": "La Roche-Jaudy",
+    "anciennesCommunes": [
+      {
+        "code": "22078",
+        "nom": "Hengoat"
+      },
+      {
+        "code": "22247",
+        "nom": "Pommerit-Jaudy"
+      },
+      {
+        "code": "22253",
+        "nom": "Pouldouran"
+      },
+      {
+        "code": "22264",
+        "nom": "La Roche-Derrien"
+      }
+    ]
+  },
+  {
+    "code": "23109",
+    "nom": "Linard-Malval",
+    "anciennesCommunes": [
+      {
+        "code": "23109",
+        "nom": "Linard"
+      },
+      {
+        "code": "23121",
+        "nom": "Malval"
+      }
+    ]
+  },
+  {
+    "code": "23149",
+    "nom": "Parsac",
+    "anciennesCommunes": [
+      {
+        "code": "23023",
+        "nom": "Blaudeix"
+      },
+      {
+        "code": "23149",
+        "nom": "Parsac"
+      },
+      {
+        "code": "23161",
+        "nom": "Rimondeix"
+      }
+    ]
+  },
+  {
+    "code": "23189",
+    "nom": "Saint-Dizier-Masbaraud",
+    "anciennesCommunes": [
+      {
+        "code": "23126",
+        "nom": "Masbaraud-Mérignat"
+      },
+      {
+        "code": "23189",
+        "nom": "Saint-Dizier-Leyrenne"
+      }
+    ]
+  },
+  {
+    "code": "23192",
+    "nom": "Fursac",
+    "anciennesCommunes": [
+      {
+        "code": "23192",
+        "nom": "Saint-Étienne-de-Fursac"
+      },
+      {
+        "code": "23231",
+        "nom": "Saint-Pierre-de-Fursac"
+      }
+    ]
+  },
+  {
+    "code": "24026",
+    "nom": "Bassillac et Auberoche",
+    "anciennesCommunes": [
+      {
+        "code": "24026",
+        "nom": "Bassillac"
+      },
+      {
+        "code": "24044",
+        "nom": "Blis-et-Born"
+      },
+      {
+        "code": "24103",
+        "nom": "Le Change"
+      },
+      {
+        "code": "24166",
+        "nom": "Eyliac"
+      },
+      {
+        "code": "24270",
+        "nom": "Milhac-d'Auberoche"
+      },
+      {
+        "code": "24369",
+        "nom": "Saint-Antoine-d'Auberoche"
+      }
+    ]
+  },
+  {
+    "code": "24028",
+    "nom": "Beaumontois en Périgord",
+    "anciennesCommunes": [
+      {
+        "code": "24028",
+        "nom": "Beaumont-du-Périgord"
+      },
+      {
+        "code": "24219",
+        "nom": "Labouquerie"
+      },
+      {
+        "code": "24310",
+        "nom": "Nojals-et-Clotte"
+      },
+      {
+        "code": "24497",
+        "nom": "Sainte-Sabine-Born"
+      }
+    ]
+  },
+  {
+    "code": "24035",
+    "nom": "Pays de Belvès",
+    "anciennesCommunes": [
+      {
+        "code": "24035",
+        "nom": "Belvès"
+      },
+      {
+        "code": "24363",
+        "nom": "Saint-Amand-de-Belvès"
+      }
+    ]
+  },
+  {
+    "code": "24053",
+    "nom": "Boulazac Isle Manoire",
+    "anciennesCommunes": [
+      {
+        "code": "24013",
+        "nom": "Atur"
+      },
+      {
+        "code": "24053",
+        "nom": "Boulazac"
+      },
+      {
+        "code": "24439",
+        "nom": "Saint-Laurent-sur-Manoire"
+      },
+      {
+        "code": "24447",
+        "nom": "Sainte-Marie-de-Chignac"
+      }
+    ]
+  },
+  {
+    "code": "24064",
+    "nom": "Brantôme en Périgord",
+    "anciennesCommunes": [
+      {
+        "code": "24064",
+        "nom": "Brantôme"
+      },
+      {
+        "code": "24079",
+        "nom": "Cantillac"
+      },
+      {
+        "code": "24170",
+        "nom": "Eyvirat"
+      },
+      {
+        "code": "24198",
+        "nom": "La Gonterie-Boulouneix"
+      },
+      {
+        "code": "24391",
+        "nom": "Saint-Crépin-de-Richemont"
+      },
+      {
+        "code": "24430",
+        "nom": "Saint-Julien-de-Bourdeilles"
+      },
+      {
+        "code": "24530",
+        "nom": "Sencenac-Puy-de-Fourches"
+      },
+      {
+        "code": "24561",
+        "nom": "Valeuil"
+      }
+    ]
+  },
+  {
+    "code": "24087",
+    "nom": "Castels et Bézenac",
+    "anciennesCommunes": [
+      {
+        "code": "24041",
+        "nom": "Bézenac"
+      },
+      {
+        "code": "24087",
+        "nom": "Castels"
+      }
+    ]
+  },
+  {
+    "code": "24117",
+    "nom": "Les Coteaux Périgourdins",
+    "anciennesCommunes": [
+      {
+        "code": "24117",
+        "nom": "Chavagnac"
+      },
+      {
+        "code": "24204",
+        "nom": "Grèzes"
+      }
+    ]
+  },
+  {
+    "code": "24142",
+    "nom": "Coux et Bigaroque-Mouzens",
+    "anciennesCommunes": [
+      {
+        "code": "24142",
+        "nom": "Coux-et-Bigaroque"
+      },
+      {
+        "code": "24298",
+        "nom": "Mouzens"
+      }
+    ]
+  },
+  {
+    "code": "24147",
+    "nom": "Cubjac-Auvézère-Val d'Ans",
+    "anciennesCommunes": [
+      {
+        "code": "24047",
+        "nom": "La Boissière-d'Ans"
+      },
+      {
+        "code": "24147",
+        "nom": "Cubjac"
+      },
+      {
+        "code": "24475",
+        "nom": "Saint-Pantaly-d'Ans"
+      }
+    ]
+  },
+  {
+    "code": "24168",
+    "nom": "Plaisance",
+    "anciennesCommunes": [
+      {
+        "code": "24168",
+        "nom": "Plaisance"
+      }
+    ]
+  },
+  {
+    "code": "24172",
+    "nom": "Les Eyzies",
+    "anciennesCommunes": [
+      {
+        "code": "24172",
+        "nom": "Les Eyzies-de-Tayac-Sireuil"
+      },
+      {
+        "code": "24249",
+        "nom": "Manaurie"
+      },
+      {
+        "code": "24389",
+        "nom": "Saint-Cirq"
+      }
+    ]
+  },
+  {
+    "code": "24216",
+    "nom": "La Jemaye-Ponteyraud",
+    "anciennesCommunes": [
+      {
+        "code": "24216",
+        "nom": "La Jemaye"
+      },
+      {
+        "code": "24333",
+        "nom": "Ponteyraud"
+      }
+    ]
+  },
+  {
+    "code": "24253",
+    "nom": "Mareuil en Périgord",
+    "anciennesCommunes": [
+      {
+        "code": "24033",
+        "nom": "Beaussac"
+      },
+      {
+        "code": "24099",
+        "nom": "Champeaux-et-la-Chapelle-Pommier"
+      },
+      {
+        "code": "24203",
+        "nom": "Les Graulges"
+      },
+      {
+        "code": "24235",
+        "nom": "Léguillac-de-Cercles"
+      },
+      {
+        "code": "24253",
+        "nom": "Mareuil"
+      },
+      {
+        "code": "24283",
+        "nom": "Monsec"
+      },
+      {
+        "code": "24344",
+        "nom": "Puyrenier"
+      },
+      {
+        "code": "24503",
+        "nom": "Saint-Sulpice-de-Mareuil"
+      },
+      {
+        "code": "24579",
+        "nom": "Vieux-Mareuil"
+      }
+    ]
+  },
+  {
+    "code": "24259",
+    "nom": "Eyraud-Crempse-Maurens",
+    "anciennesCommunes": [
+      {
+        "code": "24233",
+        "nom": "Laveyssière"
+      },
+      {
+        "code": "24259",
+        "nom": "Maurens"
+      },
+      {
+        "code": "24427",
+        "nom": "Saint-Jean-d'Eyraud"
+      },
+      {
+        "code": "24431",
+        "nom": "Saint-Julien-de-Crempse"
+      }
+    ]
+  },
+  {
+    "code": "24312",
+    "nom": "Sanilhac",
+    "anciennesCommunes": [
+      {
+        "code": "24065",
+        "nom": "Breuilh"
+      },
+      {
+        "code": "24258",
+        "nom": "Marsaneix"
+      },
+      {
+        "code": "24312",
+        "nom": "Notre-Dame-de-Sanilhac"
+      }
+    ]
+  },
+  {
+    "code": "24316",
+    "nom": "Parcoul-Chenaud",
+    "anciennesCommunes": [
+      {
+        "code": "24118",
+        "nom": "Chenaud"
+      },
+      {
+        "code": "24316",
+        "nom": "Parcoul"
+      }
+    ]
+  },
+  {
+    "code": "24325",
+    "nom": "Pechs-de-l'Espérance",
+    "anciennesCommunes": [
+      {
+        "code": "24089",
+        "nom": "Cazoulès"
+      },
+      {
+        "code": "24314",
+        "nom": "Orliaguet"
+      },
+      {
+        "code": "24325",
+        "nom": "Peyrillac-et-Millac"
+      }
+    ]
+  },
+  {
+    "code": "24362",
+    "nom": "Val de Louyre et Caudeau",
+    "anciennesCommunes": [
+      {
+        "code": "24092",
+        "nom": "Cendrieux"
+      },
+      {
+        "code": "24362",
+        "nom": "Sainte-Alvère"
+      },
+      {
+        "code": "24435",
+        "nom": "Saint-Laurent-des-Bâtons"
+      }
+    ]
+  },
+  {
+    "code": "24364",
+    "nom": "Coly-Saint-Amand",
+    "anciennesCommunes": [
+      {
+        "code": "24127",
+        "nom": "Coly"
+      },
+      {
+        "code": "24364",
+        "nom": "Saint-Amand-de-Coly"
+      }
+    ]
+  },
+  {
+    "code": "24376",
+    "nom": "Saint Aulaye-Puymangou",
+    "anciennesCommunes": [
+      {
+        "code": "24343",
+        "nom": "Puymangou"
+      },
+      {
+        "code": "24376",
+        "nom": "Saint-Aulaye"
+      }
+    ]
+  },
+  {
+    "code": "24423",
+    "nom": "Saint-Julien-Innocence-Eulalie",
+    "anciennesCommunes": [
+      {
+        "code": "24402",
+        "nom": "Sainte-Eulalie-d'Eymet"
+      },
+      {
+        "code": "24423",
+        "nom": "Sainte-Innocence"
+      },
+      {
+        "code": "24433",
+        "nom": "Saint-Julien-d'Eymet"
+      }
+    ]
+  },
+  {
+    "code": "24490",
+    "nom": "Saint Privat en Périgord",
+    "anciennesCommunes": [
+      {
+        "code": "24178",
+        "nom": "Festalemps"
+      },
+      {
+        "code": "24368",
+        "nom": "Saint-Antoine-Cumond"
+      },
+      {
+        "code": "24490",
+        "nom": "Saint-Privat-des-Prés"
+      }
+    ]
+  },
+  {
+    "code": "24534",
+    "nom": "Sigoulès-et-Flaugeac",
+    "anciennesCommunes": [
+      {
+        "code": "24181",
+        "nom": "Flaugeac"
+      },
+      {
+        "code": "24534",
+        "nom": "Sigoulès"
+      }
+    ]
+  },
+  {
+    "code": "24540",
+    "nom": "Sorges et Ligueux en Périgord",
+    "anciennesCommunes": [
+      {
+        "code": "24239",
+        "nom": "Ligueux"
+      },
+      {
+        "code": "24540",
+        "nom": "Sorges"
+      }
+    ]
+  },
+  {
+    "code": "24549",
+    "nom": "Thénac",
+    "anciennesCommunes": [
+      {
+        "code": "24549",
+        "nom": "Thénac"
+      }
+    ]
+  },
+  {
+    "code": "24554",
+    "nom": "La Tour-Blanche-Cercles",
+    "anciennesCommunes": [
+      {
+        "code": "24093",
+        "nom": "Cercles"
+      },
+      {
+        "code": "24554",
+        "nom": "La Tour-Blanche"
+      }
+    ]
+  },
+  {
+    "code": "25035",
+    "nom": "Les Auxons",
+    "anciennesCommunes": [
+      {
+        "code": "25034",
+        "nom": "Auxon-Dessous"
+      },
+      {
+        "code": "25035",
+        "nom": "Auxon-Dessus"
+      }
+    ]
+  },
+  {
+    "code": "25060",
+    "nom": "Val-d'Usiers",
+    "anciennesCommunes": [
+      {
+        "code": "25060",
+        "nom": "Bians-les-Usiers"
+      },
+      {
+        "code": "25282",
+        "nom": "Goux-les-Usiers"
+      },
+      {
+        "code": "25549",
+        "nom": "Sombacour"
+      }
+    ]
+  },
+  {
+    "code": "25078",
+    "nom": "Bouclans",
+    "anciennesCommunes": [
+      {
+        "code": "25078",
+        "nom": "Bouclans"
+      },
+      {
+        "code": "25587",
+        "nom": "Vauchamps"
+      }
+    ]
+  },
+  {
+    "code": "25147",
+    "nom": "Chemaudin et Vaux",
+    "anciennesCommunes": [
+      {
+        "code": "25147",
+        "nom": "Chemaudin"
+      },
+      {
+        "code": "25593",
+        "nom": "Vaux-les-Prés"
+      }
+    ]
+  },
+  {
+    "code": "25156",
+    "nom": "Pays-de-Clerval",
+    "anciennesCommunes": [
+      {
+        "code": "25140",
+        "nom": "Chaux-lès-Clerval"
+      },
+      {
+        "code": "25156",
+        "nom": "Clerval"
+      },
+      {
+        "code": "25531",
+        "nom": "Santoche"
+      }
+    ]
+  },
+  {
+    "code": "25185",
+    "nom": "Cussey-sur-Lison",
+    "anciennesCommunes": [
+      {
+        "code": "25134",
+        "nom": "Châtillon-sur-Lison"
+      },
+      {
+        "code": "25185",
+        "nom": "Cussey-sur-Lison"
+      }
+    ]
+  },
+  {
+    "code": "25222",
+    "nom": "Étalans",
+    "anciennesCommunes": [
+      {
+        "code": "25123",
+        "nom": "Charbonnières-les-Sapins"
+      },
+      {
+        "code": "25222",
+        "nom": "Étalans"
+      },
+      {
+        "code": "25610",
+        "nom": "Verrières-du-Grosbois"
+      }
+    ]
+  },
+  {
+    "code": "25223",
+    "nom": "Éternoz-Vallée-du-Lison",
+    "anciennesCommunes": [
+      {
+        "code": "25223",
+        "nom": "Éternoz"
+      },
+      {
+        "code": "25533",
+        "nom": "Saraz"
+      }
+    ]
+  },
+  {
+    "code": "25245",
+    "nom": "Fontain",
+    "anciennesCommunes": [
+      {
+        "code": "25027",
+        "nom": "Arguel"
+      },
+      {
+        "code": "25245",
+        "nom": "Fontain"
+      }
+    ]
+  },
+  {
+    "code": "25334",
+    "nom": "Levier",
+    "anciennesCommunes": [
+      {
+        "code": "25319",
+        "nom": "Labergement-du-Navois"
+      },
+      {
+        "code": "25334",
+        "nom": "Levier"
+      }
+    ]
+  },
+  {
+    "code": "25364",
+    "nom": "Mamirolle",
+    "anciennesCommunes": [
+      {
+        "code": "25297",
+        "nom": "Le Gratteris"
+      },
+      {
+        "code": "25364",
+        "nom": "Mamirolle"
+      }
+    ]
+  },
+  {
+    "code": "25368",
+    "nom": "Marchaux-Chaudefontaine",
+    "anciennesCommunes": [
+      {
+        "code": "25137",
+        "nom": "Chaudefontaine"
+      },
+      {
+        "code": "25368",
+        "nom": "Marchaux"
+      }
+    ]
+  },
+  {
+    "code": "25375",
+    "nom": "Les Monts-Ronds",
+    "anciennesCommunes": [
+      {
+        "code": "25375",
+        "nom": "Mérey-sous-Montrond"
+      },
+      {
+        "code": "25628",
+        "nom": "Villers-sous-Montrond"
+      }
+    ]
+  },
+  {
+    "code": "25390",
+    "nom": "Pays-de-Montbenoît",
+    "anciennesCommunes": [
+      {
+        "code": "25303",
+        "nom": "Hauterive-la-Fresse"
+      },
+      {
+        "code": "25347",
+        "nom": "La Longeville"
+      },
+      {
+        "code": "25390",
+        "nom": "Montbenoît"
+      },
+      {
+        "code": "25398",
+        "nom": "Montflovin"
+      },
+      {
+        "code": "25620",
+        "nom": "Ville-du-Pont"
+      }
+    ]
+  },
+  {
+    "code": "25424",
+    "nom": "Les Premiers Sapins",
+    "anciennesCommunes": [
+      {
+        "code": "25028",
+        "nom": "Athose"
+      },
+      {
+        "code": "25128",
+        "nom": "Chasnans"
+      },
+      {
+        "code": "25302",
+        "nom": "Hautepierre-le-Châtelet"
+      },
+      {
+        "code": "25424",
+        "nom": "Nods"
+      },
+      {
+        "code": "25480",
+        "nom": "Rantechaux"
+      },
+      {
+        "code": "25585",
+        "nom": "Vanclans"
+      }
+    ]
+  },
+  {
+    "code": "25434",
+    "nom": "Ornans",
+    "anciennesCommunes": [
+      {
+        "code": "25076",
+        "nom": "Bonnevaux-le-Prieuré"
+      },
+      {
+        "code": "25434",
+        "nom": "Ornans"
+      }
+    ]
+  },
+  {
+    "code": "25438",
+    "nom": "Osselle-Routelle",
+    "anciennesCommunes": [
+      {
+        "code": "25438",
+        "nom": "Osselle"
+      },
+      {
+        "code": "25509",
+        "nom": "Routelle"
+      }
+    ]
+  },
+  {
+    "code": "25460",
+    "nom": "Le Val",
+    "anciennesCommunes": [
+      {
+        "code": "25399",
+        "nom": "Montfort"
+      },
+      {
+        "code": "25460",
+        "nom": "Pointvillers"
+      }
+    ]
+  },
+  {
+    "code": "25463",
+    "nom": "Pont-de-Roide-Vermondans",
+    "anciennesCommunes": [
+      {
+        "code": "25463",
+        "nom": "Pont-de-Roide"
+      }
+    ]
+  },
+  {
+    "code": "25529",
+    "nom": "Sancey",
+    "anciennesCommunes": [
+      {
+        "code": "25529",
+        "nom": "Sancey-le-Grand"
+      },
+      {
+        "code": "25530",
+        "nom": "Sancey-le-Long"
+      }
+    ]
+  },
+  {
+    "code": "25558",
+    "nom": "Tarcenay-Foucherans",
+    "anciennesCommunes": [
+      {
+        "code": "25250",
+        "nom": "Foucherans"
+      },
+      {
+        "code": "25558",
+        "nom": "Tarcenay"
+      }
+    ]
+  },
+  {
+    "code": "25575",
+    "nom": "Vaire",
+    "anciennesCommunes": [
+      {
+        "code": "25575",
+        "nom": "Vaire-Arcier"
+      },
+      {
+        "code": "25576",
+        "nom": "Vaire-le-Petit"
+      }
+    ]
+  },
+  {
+    "code": "26001",
+    "nom": "Solaure en Diois",
+    "anciennesCommunes": [
+      {
+        "code": "26001",
+        "nom": "Aix-en-Diois"
+      },
+      {
+        "code": "26187",
+        "nom": "Molières-Glandaz"
+      }
+    ]
+  },
+  {
+    "code": "26086",
+    "nom": "Châtillon-en-Diois",
+    "anciennesCommunes": [
+      {
+        "code": "26086",
+        "nom": "Châtillon-en-Diois"
+      },
+      {
+        "code": "26354",
+        "nom": "Treschenu-Creyers"
+      }
+    ]
+  },
+  {
+    "code": "26179",
+    "nom": "Mercurol-Veaunes",
+    "anciennesCommunes": [
+      {
+        "code": "26179",
+        "nom": "Mercurol"
+      },
+      {
+        "code": "26366",
+        "nom": "Veaunes"
+      }
+    ]
+  },
+  {
+    "code": "26210",
+    "nom": "Valherbasse",
+    "anciennesCommunes": [
+      {
+        "code": "26184",
+        "nom": "Miribel"
+      },
+      {
+        "code": "26210",
+        "nom": "Montrigaud"
+      },
+      {
+        "code": "26297",
+        "nom": "Saint-Bonnet-de-Valclérieux"
+      }
+    ]
+  },
+  {
+    "code": "26216",
+    "nom": "Saint-Jean-de-Galaure",
+    "anciennesCommunes": [
+      {
+        "code": "26216",
+        "nom": "La Motte-de-Galaure"
+      },
+      {
+        "code": "26219",
+        "nom": "Mureils"
+      }
+    ]
+  },
+  {
+    "code": "26289",
+    "nom": "Saillans",
+    "anciennesCommunes": [
+      {
+        "code": "26289",
+        "nom": "Saillans"
+      },
+      {
+        "code": "26371",
+        "nom": "Véronne"
+      }
+    ]
+  },
+  {
+    "code": "27011",
+    "nom": "Amfreville-Saint-Amand",
+    "anciennesCommunes": [
+      {
+        "code": "27011",
+        "nom": "Amfreville-la-Campagne"
+      },
+      {
+        "code": "27506",
+        "nom": "Saint-Amand-des-Hautes-Terres"
+      }
+    ]
+  },
+  {
+    "code": "27022",
+    "nom": "Le Val d'Hazey",
+    "anciennesCommunes": [
+      {
+        "code": "27022",
+        "nom": "Aubevoye"
+      },
+      {
+        "code": "27519",
+        "nom": "Sainte-Barbe-sur-Gaillon"
+      },
+      {
+        "code": "27687",
+        "nom": "Vieux-Villez"
+      }
+    ]
+  },
+  {
+    "code": "27032",
+    "nom": "Chambois",
+    "anciennesCommunes": [
+      {
+        "code": "27032",
+        "nom": "Avrilly"
+      },
+      {
+        "code": "27172",
+        "nom": "Corneuil"
+      },
+      {
+        "code": "27634",
+        "nom": "Thomer-la-Sôgne"
+      }
+    ]
+  },
+  {
+    "code": "27049",
+    "nom": "Mesnil-en-Ouche",
+    "anciennesCommunes": [
+      {
+        "code": "27007",
+        "nom": "Ajou"
+      },
+      {
+        "code": "27041",
+        "nom": "La Barre-en-Ouche"
+      },
+      {
+        "code": "27049",
+        "nom": "Beaumesnil"
+      },
+      {
+        "code": "27088",
+        "nom": "Bosc-Renoult-en-Ouche"
+      },
+      {
+        "code": "27221",
+        "nom": "Épinay"
+      },
+      {
+        "code": "27283",
+        "nom": "Gisay-la-Coudre"
+      },
+      {
+        "code": "27292",
+        "nom": "Gouttières"
+      },
+      {
+        "code": "27296",
+        "nom": "Granchain"
+      },
+      {
+        "code": "27356",
+        "nom": "Jonquerets-de-Livet"
+      },
+      {
+        "code": "27362",
+        "nom": "Landepéreuse"
+      },
+      {
+        "code": "27499",
+        "nom": "La Roussière"
+      },
+      {
+        "code": "27513",
+        "nom": "Saint-Aubin-des-Hayes"
+      },
+      {
+        "code": "27515",
+        "nom": "Saint-Aubin-le-Guichard"
+      },
+      {
+        "code": "27566",
+        "nom": "Sainte-Marguerite-en-Ouche"
+      },
+      {
+        "code": "27596",
+        "nom": "Saint-Pierre-du-Mesnil"
+      },
+      {
+        "code": "27628",
+        "nom": "Thevray"
+      }
+    ]
+  },
+  {
+    "code": "27062",
+    "nom": "Les Monts du Roumois",
+    "anciennesCommunes": [
+      {
+        "code": "27062",
+        "nom": "Berville-en-Roumois"
+      },
+      {
+        "code": "27092",
+        "nom": "Bosguérard-de-Marcouville"
+      },
+      {
+        "code": "27344",
+        "nom": "Houlbec-près-le-Gros-Theil"
+      }
+    ]
+  },
+  {
+    "code": "27070",
+    "nom": "Frenelles-en-Vexin",
+    "anciennesCommunes": [
+      {
+        "code": "27070",
+        "nom": "Boisemont"
+      },
+      {
+        "code": "27175",
+        "nom": "Corny"
+      },
+      {
+        "code": "27270",
+        "nom": "Fresne-l'Archevêque"
+      }
+    ]
+  },
+  {
+    "code": "27085",
+    "nom": "Flancourt-Crescy-en-Roumois",
+    "anciennesCommunes": [
+      {
+        "code": "27085",
+        "nom": "Bosc-Bénard-Crescy"
+      },
+      {
+        "code": "27223",
+        "nom": "Épreville-en-Roumois"
+      },
+      {
+        "code": "27244",
+        "nom": "Flancourt-Catelon"
+      }
+    ]
+  },
+  {
+    "code": "27089",
+    "nom": "Thénouville",
+    "anciennesCommunes": [
+      {
+        "code": "27089",
+        "nom": "Bosc-Renoult-en-Roumois"
+      },
+      {
+        "code": "27626",
+        "nom": "Theillement"
+      },
+      {
+        "code": "27657",
+        "nom": "Touville"
+      }
+    ]
+  },
+  {
+    "code": "27090",
+    "nom": "Bosroumois",
+    "anciennesCommunes": [
+      {
+        "code": "27090",
+        "nom": "Le Bosc-Roger-en-Roumois"
+      },
+      {
+        "code": "27093",
+        "nom": "Bosnormand"
+      }
+    ]
+  },
+  {
+    "code": "27105",
+    "nom": "Grand Bourgtheroulde",
+    "anciennesCommunes": [
+      {
+        "code": "27084",
+        "nom": "Bosc-Bénard-Commin"
+      },
+      {
+        "code": "27105",
+        "nom": "Bourgtheroulde-Infreville"
+      },
+      {
+        "code": "27637",
+        "nom": "Thuit-Hébert"
+      }
+    ]
+  },
+  {
+    "code": "27107",
+    "nom": "Bourneville-Sainte-Croix",
+    "anciennesCommunes": [
+      {
+        "code": "27107",
+        "nom": "Bourneville"
+      },
+      {
+        "code": "27526",
+        "nom": "Sainte-Croix-sur-Aizier"
+      }
+    ]
+  },
+  {
+    "code": "27112",
+    "nom": "Breteuil",
+    "anciennesCommunes": [
+      {
+        "code": "27112",
+        "nom": "Breteuil"
+      },
+      {
+        "code": "27159",
+        "nom": "Cintray"
+      },
+      {
+        "code": "27305",
+        "nom": "La Guéroulde"
+      }
+    ]
+  },
+  {
+    "code": "27157",
+    "nom": "Marbois",
+    "anciennesCommunes": [
+      {
+        "code": "27145",
+        "nom": "Chanteloup"
+      },
+      {
+        "code": "27157",
+        "nom": "Le Chesne"
+      },
+      {
+        "code": "27225",
+        "nom": "Les Essarts"
+      },
+      {
+        "code": "27532",
+        "nom": "Saint-Denis-du-Béhélan"
+      }
+    ]
+  },
+  {
+    "code": "27191",
+    "nom": "Clef Vallée d'Eure",
+    "anciennesCommunes": [
+      {
+        "code": "27191",
+        "nom": "La Croix-Saint-Leufroy"
+      },
+      {
+        "code": "27211",
+        "nom": "Écardenville-sur-Eure"
+      },
+      {
+        "code": "27250",
+        "nom": "Fontaine-Heudebourg"
+      }
+    ]
+  },
+  {
+    "code": "27198",
+    "nom": "Mesnils-sur-Iton",
+    "anciennesCommunes": [
+      {
+        "code": "27024",
+        "nom": "Le Roncenay-Authenay"
+      },
+      {
+        "code": "27166",
+        "nom": "Condé-sur-Iton"
+      },
+      {
+        "code": "27198",
+        "nom": "Damville"
+      },
+      {
+        "code": "27293",
+        "nom": "Gouville"
+      },
+      {
+        "code": "27297",
+        "nom": "Grandvilliers"
+      },
+      {
+        "code": "27387",
+        "nom": "Manthelon"
+      },
+      {
+        "code": "27416",
+        "nom": "Buis-sur-Damville"
+      },
+      {
+        "code": "27491",
+        "nom": "Roman"
+      },
+      {
+        "code": "27503",
+        "nom": "Le Sacq"
+      }
+    ]
+  },
+  {
+    "code": "27213",
+    "nom": "Vexin-sur-Epte",
+    "anciennesCommunes": [
+      {
+        "code": "27060",
+        "nom": "Berthenonville"
+      },
+      {
+        "code": "27121",
+        "nom": "Bus-Saint-Rémy"
+      },
+      {
+        "code": "27122",
+        "nom": "Cahaignes"
+      },
+      {
+        "code": "27128",
+        "nom": "Cantiers"
+      },
+      {
+        "code": "27160",
+        "nom": "Civières"
+      },
+      {
+        "code": "27197",
+        "nom": "Dampsmesnil"
+      },
+      {
+        "code": "27213",
+        "nom": "Écos"
+      },
+      {
+        "code": "27255",
+        "nom": "Fontenay-en-Vexin"
+      },
+      {
+        "code": "27257",
+        "nom": "Forêt-la-Folie"
+      },
+      {
+        "code": "27262",
+        "nom": "Fourges"
+      },
+      {
+        "code": "27264",
+        "nom": "Fours-en-Vexin"
+      },
+      {
+        "code": "27308",
+        "nom": "Guitry"
+      },
+      {
+        "code": "27449",
+        "nom": "Panilleuse"
+      },
+      {
+        "code": "27653",
+        "nom": "Tourny"
+      }
+    ]
+  },
+  {
+    "code": "27263",
+    "nom": "Le Perrey",
+    "anciennesCommunes": [
+      {
+        "code": "27263",
+        "nom": "Fourmetot"
+      },
+      {
+        "code": "27581",
+        "nom": "Saint-Ouen-des-Champs"
+      },
+      {
+        "code": "27607",
+        "nom": "Saint-Thurien"
+      }
+    ]
+  },
+  {
+    "code": "27277",
+    "nom": "La Baronnie",
+    "anciennesCommunes": [
+      {
+        "code": "27277",
+        "nom": "Garencières"
+      },
+      {
+        "code": "27484",
+        "nom": "Quessigny"
+      }
+    ]
+  },
+  {
+    "code": "27290",
+    "nom": "Goupil-Othon",
+    "anciennesCommunes": [
+      {
+        "code": "27290",
+        "nom": "Goupillières"
+      },
+      {
+        "code": "27642",
+        "nom": "Le Tilleul-Othon"
+      }
+    ]
+  },
+  {
+    "code": "27294",
+    "nom": "Val d'Orger",
+    "anciennesCommunes": [
+      {
+        "code": "27274",
+        "nom": "Gaillardbois-Cressenville"
+      },
+      {
+        "code": "27294",
+        "nom": "Grainville"
+      }
+    ]
+  },
+  {
+    "code": "27302",
+    "nom": "Le Bosc du Theil",
+    "anciennesCommunes": [
+      {
+        "code": "27302",
+        "nom": "Le Gros-Theil"
+      },
+      {
+        "code": "27574",
+        "nom": "Saint-Nicolas-du-Bosc"
+      }
+    ]
+  },
+  {
+    "code": "27412",
+    "nom": "Terres de Bord",
+    "anciennesCommunes": [
+      {
+        "code": "27412",
+        "nom": "Montaure"
+      },
+      {
+        "code": "27648",
+        "nom": "Tostes"
+      }
+    ]
+  },
+  {
+    "code": "27425",
+    "nom": "Nassandres sur Risle",
+    "anciennesCommunes": [
+      {
+        "code": "27131",
+        "nom": "Carsix"
+      },
+      {
+        "code": "27253",
+        "nom": "Fontaine-la-Soret"
+      },
+      {
+        "code": "27425",
+        "nom": "Nassandres"
+      },
+      {
+        "code": "27452",
+        "nom": "Perriers-la-Campagne"
+      }
+    ]
+  },
+  {
+    "code": "27447",
+    "nom": "Le Val-Doré",
+    "anciennesCommunes": [
+      {
+        "code": "27268",
+        "nom": "Le Fresne"
+      },
+      {
+        "code": "27402",
+        "nom": "Le Mesnil-Hardray"
+      },
+      {
+        "code": "27447",
+        "nom": "Orvaux"
+      }
+    ]
+  },
+  {
+    "code": "27448",
+    "nom": "Pacy-sur-Eure",
+    "anciennesCommunes": [
+      {
+        "code": "27448",
+        "nom": "Pacy-sur-Eure"
+      },
+      {
+        "code": "27510",
+        "nom": "Saint-Aquilin-de-Pacy"
+      }
+    ]
+  },
+  {
+    "code": "27467",
+    "nom": "Pont-Audemer",
+    "anciennesCommunes": [
+      {
+        "code": "27467",
+        "nom": "Pont-Audemer"
+      },
+      {
+        "code": "27549",
+        "nom": "Saint-Germain-Village"
+      }
+    ]
+  },
+  {
+    "code": "27471",
+    "nom": "Porte-de-Seine",
+    "anciennesCommunes": [
+      {
+        "code": "27471",
+        "nom": "Porte-Joie"
+      },
+      {
+        "code": "27651",
+        "nom": "Tournedos-sur-Seine"
+      }
+    ]
+  },
+  {
+    "code": "27516",
+    "nom": "Treis-Sants-en-Ouche",
+    "anciennesCommunes": [
+      {
+        "code": "27516",
+        "nom": "Saint-Aubin-le-Vertueux"
+      },
+      {
+        "code": "27523",
+        "nom": "Saint-Clair-d'Arcey"
+      },
+      {
+        "code": "27600",
+        "nom": "Saint-Quentin-des-Isles"
+      }
+    ]
+  },
+  {
+    "code": "27541",
+    "nom": "Le Mesnil-Saint-Jean",
+    "anciennesCommunes": [
+      {
+        "code": "27541",
+        "nom": "Saint-Georges-du-Mesnil"
+      },
+      {
+        "code": "27551",
+        "nom": "Saint-Jean-de-la-Léqueraye"
+      }
+    ]
+  },
+  {
+    "code": "27554",
+    "nom": "La Chapelle-Longueville",
+    "anciennesCommunes": [
+      {
+        "code": "27150",
+        "nom": "La Chapelle-Réanville"
+      },
+      {
+        "code": "27554",
+        "nom": "Saint-Just"
+      },
+      {
+        "code": "27588",
+        "nom": "Saint-Pierre-d'Autils"
+      }
+    ]
+  },
+  {
+    "code": "27565",
+    "nom": "Le Lesme",
+    "anciennesCommunes": [
+      {
+        "code": "27303",
+        "nom": "Guernanville"
+      },
+      {
+        "code": "27565",
+        "nom": "Sainte-Marguerite-de-l'Autel"
+      }
+    ]
+  },
+  {
+    "code": "27578",
+    "nom": "Sainte-Marie-d'Attez",
+    "anciennesCommunes": [
+      {
+        "code": "27195",
+        "nom": "Dame-Marie"
+      },
+      {
+        "code": "27573",
+        "nom": "Saint-Nicolas-d'Attez"
+      },
+      {
+        "code": "27578",
+        "nom": "Saint-Ouen-d'Attez"
+      }
+    ]
+  },
+  {
+    "code": "27638",
+    "nom": "Le Thuit de l'Oison",
+    "anciennesCommunes": [
+      {
+        "code": "27636",
+        "nom": "Le Thuit-Anger"
+      },
+      {
+        "code": "27638",
+        "nom": "Le Thuit-Signol"
+      },
+      {
+        "code": "27639",
+        "nom": "Le Thuit-Simer"
+      }
+    ]
+  },
+  {
+    "code": "27679",
+    "nom": "Verneuil d'Avre et d'Iton",
+    "anciennesCommunes": [
+      {
+        "code": "27265",
+        "nom": "Francheville"
+      },
+      {
+        "code": "27679",
+        "nom": "Verneuil-sur-Avre"
+      }
+    ]
+  },
+  {
+    "code": "27685",
+    "nom": "La Vieille-Lyre",
+    "anciennesCommunes": [
+      {
+        "code": "27143",
+        "nom": "Champignolles"
+      },
+      {
+        "code": "27685",
+        "nom": "La Vieille-Lyre"
+      }
+    ]
+  },
+  {
+    "code": "27693",
+    "nom": "Sylvains-Lès-Moulins",
+    "anciennesCommunes": [
+      {
+        "code": "27688",
+        "nom": "Villalet"
+      },
+      {
+        "code": "27693",
+        "nom": "Sylvains-les-Moulins"
+      }
+    ]
+  },
+  {
+    "code": "28012",
+    "nom": "Vald'Yerre",
+    "anciennesCommunes": [
+      {
+        "code": "28012",
+        "nom": "Arrou"
+      },
+      {
+        "code": "28044",
+        "nom": "Boisgasson"
+      },
+      {
+        "code": "28093",
+        "nom": "Châtillon-en-Dunois"
+      },
+      {
+        "code": "28115",
+        "nom": "Courtalain"
+      },
+      {
+        "code": "28204",
+        "nom": "Langey"
+      },
+      {
+        "code": "28356",
+        "nom": "Saint-Pellerin"
+      }
+    ]
+  },
+  {
+    "code": "28015",
+    "nom": "Auneau-Bleury-Saint-Symphorien",
+    "anciennesCommunes": [
+      {
+        "code": "28015",
+        "nom": "Auneau"
+      },
+      {
+        "code": "28361",
+        "nom": "Bleury-Saint-Symphorien"
+      }
+    ]
+  },
+  {
+    "code": "28018",
+    "nom": "Authon-du-Perche",
+    "anciennesCommunes": [
+      {
+        "code": "28018",
+        "nom": "Authon-du-Perche"
+      },
+      {
+        "code": "28376",
+        "nom": "Soizé"
+      }
+    ]
+  },
+  {
+    "code": "28103",
+    "nom": "Cloyes-les-Trois-Rivières",
+    "anciennesCommunes": [
+      {
+        "code": "28017",
+        "nom": "Autheuil"
+      },
+      {
+        "code": "28083",
+        "nom": "Charray"
+      },
+      {
+        "code": "28103",
+        "nom": "Cloyes-sur-le-Loir"
+      },
+      {
+        "code": "28133",
+        "nom": "Douy"
+      },
+      {
+        "code": "28150",
+        "nom": "La Ferté-Villeneuil"
+      },
+      {
+        "code": "28241",
+        "nom": "Le Mée"
+      },
+      {
+        "code": "28262",
+        "nom": "Montigny-le-Gannelon"
+      },
+      {
+        "code": "28318",
+        "nom": "Romilly-sur-Aigre"
+      },
+      {
+        "code": "28340",
+        "nom": "Saint-Hilaire-sur-Yerre"
+      }
+    ]
+  },
+  {
+    "code": "28127",
+    "nom": "Dangeau",
+    "anciennesCommunes": [
+      {
+        "code": "28066",
+        "nom": "Bullou"
+      },
+      {
+        "code": "28127",
+        "nom": "Dangeau"
+      },
+      {
+        "code": "28250",
+        "nom": "Mézières-au-Perche"
+      }
+    ]
+  },
+  {
+    "code": "28183",
+    "nom": "Gommerville",
+    "anciennesCommunes": [
+      {
+        "code": "28183",
+        "nom": "Gommerville"
+      },
+      {
+        "code": "28288",
+        "nom": "Orlu"
+      }
+    ]
+  },
+  {
+    "code": "28185",
+    "nom": "Goussainville",
+    "anciennesCommunes": [
+      {
+        "code": "28069",
+        "nom": "Champagne"
+      },
+      {
+        "code": "28185",
+        "nom": "Goussainville"
+      }
+    ]
+  },
+  {
+    "code": "28199",
+    "nom": "Janville-en-Beauce",
+    "anciennesCommunes": [
+      {
+        "code": "28002",
+        "nom": "Allaines-Mervilliers"
+      },
+      {
+        "code": "28199",
+        "nom": "Janville"
+      },
+      {
+        "code": "28311",
+        "nom": "Le Puiset"
+      }
+    ]
+  },
+  {
+    "code": "28236",
+    "nom": "Arcisses",
+    "anciennesCommunes": [
+      {
+        "code": "28063",
+        "nom": "Brunelles"
+      },
+      {
+        "code": "28112",
+        "nom": "Coudreceau"
+      },
+      {
+        "code": "28236",
+        "nom": "Margon"
+      }
+    ]
+  },
+  {
+    "code": "28254",
+    "nom": "Mittainvilliers-Vérigny",
+    "anciennesCommunes": [
+      {
+        "code": "28254",
+        "nom": "Mittainvilliers"
+      },
+      {
+        "code": "28402",
+        "nom": "Vérigny"
+      }
+    ]
+  },
+  {
+    "code": "28319",
+    "nom": "Neuville Saint Denis",
+    "anciennesCommunes": [
+      {
+        "code": "28025",
+        "nom": "Barmainville"
+      },
+      {
+        "code": "28276",
+        "nom": "Neuvy-en-Beauce"
+      },
+      {
+        "code": "28319",
+        "nom": "Rouvray-Saint-Denis"
+      }
+    ]
+  },
+  {
+    "code": "28330",
+    "nom": "Villemaury",
+    "anciennesCommunes": [
+      {
+        "code": "28101",
+        "nom": "Civry"
+      },
+      {
+        "code": "28224",
+        "nom": "Lutz-en-Dunois"
+      },
+      {
+        "code": "28295",
+        "nom": "Ozoir-le-Breuil"
+      },
+      {
+        "code": "28330",
+        "nom": "Saint-Cloud-en-Dunois"
+      }
+    ]
+  },
+  {
+    "code": "28331",
+    "nom": "Saintigny",
+    "anciennesCommunes": [
+      {
+        "code": "28165",
+        "nom": "Frétigny"
+      },
+      {
+        "code": "28331",
+        "nom": "Saint-Denis-d'Authou"
+      }
+    ]
+  },
+  {
+    "code": "28334",
+    "nom": "Saint-Denis-Lanneray",
+    "anciennesCommunes": [
+      {
+        "code": "28205",
+        "nom": "Lanneray"
+      },
+      {
+        "code": "28334",
+        "nom": "Saint-Denis-les-Ponts"
+      }
+    ]
+  },
+  {
+    "code": "28383",
+    "nom": "Theuville",
+    "anciennesCommunes": [
+      {
+        "code": "28297",
+        "nom": "Pézy"
+      },
+      {
+        "code": "28383",
+        "nom": "Theuville"
+      }
+    ]
+  },
+  {
+    "code": "28406",
+    "nom": "Éole-en-Beauce",
+    "anciennesCommunes": [
+      {
+        "code": "28020",
+        "nom": "Baignolet"
+      },
+      {
+        "code": "28145",
+        "nom": "Fains-la-Folie"
+      },
+      {
+        "code": "28179",
+        "nom": "Germignonville"
+      },
+      {
+        "code": "28406",
+        "nom": "Viabon"
+      },
+      {
+        "code": "28412",
+        "nom": "Villeau"
+      }
+    ]
+  },
+  {
+    "code": "28422",
+    "nom": "Les Villages Vovéens",
+    "anciennesCommunes": [
+      {
+        "code": "28258",
+        "nom": "Montainville"
+      },
+      {
+        "code": "28320",
+        "nom": "Rouvray-Saint-Florentin"
+      },
+      {
+        "code": "28416",
+        "nom": "Villeneuve-Saint-Nicolas"
+      },
+      {
+        "code": "28422",
+        "nom": "Voves"
+      }
+    ]
+  },
+  {
+    "code": "29003",
+    "nom": "Audierne",
+    "anciennesCommunes": [
+      {
+        "code": "29003",
+        "nom": "Audierne"
+      },
+      {
+        "code": "29052",
+        "nom": "Esquibien"
+      }
+    ]
+  },
+  {
+    "code": "29021",
+    "nom": "Plounéour-Brignogan-plages",
+    "anciennesCommunes": [
+      {
+        "code": "29021",
+        "nom": "Brignogan-Plages"
+      },
+      {
+        "code": "29203",
+        "nom": "Plounéour-Trez"
+      }
+    ]
+  },
+  {
+    "code": "29076",
+    "nom": "Milizac-Guipronvel",
+    "anciennesCommunes": [
+      {
+        "code": "29076",
+        "nom": "Guipronvel"
+      },
+      {
+        "code": "29149",
+        "nom": "Milizac"
+      }
+    ]
+  },
+  {
+    "code": "29199",
+    "nom": "Plouigneau",
+    "anciennesCommunes": [
+      {
+        "code": "29199",
+        "nom": "Plouigneau"
+      },
+      {
+        "code": "29219",
+        "nom": "Le Ponthou"
+      }
+    ]
+  },
+  {
+    "code": "29227",
+    "nom": "Poullaouen",
+    "anciennesCommunes": [
+      {
+        "code": "29129",
+        "nom": "Locmaria-Berrien"
+      },
+      {
+        "code": "29227",
+        "nom": "Poullaouen"
+      }
+    ]
+  },
+  {
+    "code": "29266",
+    "nom": "Saint-Thégonnec Loc-Eguiner",
+    "anciennesCommunes": [
+      {
+        "code": "29127",
+        "nom": "Loc-Eguiner-Saint-Thégonnec"
+      },
+      {
+        "code": "29266",
+        "nom": "Saint-Thégonnec"
+      }
+    ]
+  },
+  {
+    "code": "30052",
+    "nom": "Bréau-Mars",
+    "anciennesCommunes": [
+      {
+        "code": "30052",
+        "nom": "Bréau-et-Salagosse"
+      },
+      {
+        "code": "30157",
+        "nom": "Mars"
+      }
+    ]
+  },
+  {
+    "code": "30329",
+    "nom": "Thoiras-Corbès",
+    "anciennesCommunes": [
+      {
+        "code": "30094",
+        "nom": "Corbès"
+      },
+      {
+        "code": "30329",
+        "nom": "Thoiras"
+      }
+    ]
+  },
+  {
+    "code": "30339",
+    "nom": "Val-d'Aigoual",
+    "anciennesCommunes": [
+      {
+        "code": "30190",
+        "nom": "Notre-Dame-de-la-Rouvière"
+      },
+      {
+        "code": "30339",
+        "nom": "Valleraugue"
+      }
+    ]
+  },
+  {
+    "code": "31277",
+    "nom": "Lasserre-Pradère",
+    "anciennesCommunes": [
+      {
+        "code": "31277",
+        "nom": "Lasserre"
+      },
+      {
+        "code": "31438",
+        "nom": "Pradère-les-Bourguets"
+      }
+    ]
+  },
+  {
+    "code": "31412",
+    "nom": "Péguilhan",
+    "anciennesCommunes": [
+      {
+        "code": "31307",
+        "nom": "Lunax"
+      },
+      {
+        "code": "31412",
+        "nom": "Péguilhan"
+      }
+    ]
+  },
+  {
+    "code": "31471",
+    "nom": "Saint-Béat-Lez",
+    "anciennesCommunes": [
+      {
+        "code": "31298",
+        "nom": "Lez"
+      },
+      {
+        "code": "31471",
+        "nom": "Saint-Béat"
+      }
+    ]
+  },
+  {
+    "code": "32079",
+    "nom": "Castelnau d'Auzan Labarrère",
+    "anciennesCommunes": [
+      {
+        "code": "32079",
+        "nom": "Castelnau-d'Auzan"
+      },
+      {
+        "code": "32168",
+        "nom": "Labarrère"
+      }
+    ]
+  },
+  {
+    "code": "32344",
+    "nom": "Riscle",
+    "anciennesCommunes": [
+      {
+        "code": "32074",
+        "nom": "Cannet"
+      },
+      {
+        "code": "32344",
+        "nom": "Riscle"
+      }
+    ]
+  },
+  {
+    "code": "32365",
+    "nom": "Cap d'Astarac",
+    "anciennesCommunes": [
+      {
+        "code": "32067",
+        "nom": "Cabas-Loumassès"
+      },
+      {
+        "code": "32260",
+        "nom": "Monbardon"
+      },
+      {
+        "code": "32365",
+        "nom": "Saint-Blancard"
+      },
+      {
+        "code": "32413",
+        "nom": "Sarcos"
+      }
+    ]
+  },
+  {
+    "code": "33008",
+    "nom": "Porte-de-Benauge",
+    "anciennesCommunes": [
+      {
+        "code": "33008",
+        "nom": "Arbis"
+      },
+      {
+        "code": "33092",
+        "nom": "Cantois"
+      },
+      {
+        "code": "33409",
+        "nom": "Saint-Genis-du-Bois"
+      }
+    ]
+  },
+  {
+    "code": "33018",
+    "nom": "Val de Virvée",
+    "anciennesCommunes": [
+      {
+        "code": "33018",
+        "nom": "Aubie-et-Espessas"
+      },
+      {
+        "code": "33371",
+        "nom": "Saint-Antoine"
+      },
+      {
+        "code": "33495",
+        "nom": "Salignac"
+      }
+    ]
+  },
+  {
+    "code": "33055",
+    "nom": "Blaignan-Prignac",
+    "anciennesCommunes": [
+      {
+        "code": "33055",
+        "nom": "Blaignan"
+      },
+      {
+        "code": "33338",
+        "nom": "Prignac-en-Médoc"
+      }
+    ]
+  },
+  {
+    "code": "33106",
+    "nom": "Castets et Castillon",
+    "anciennesCommunes": [
+      {
+        "code": "33106",
+        "nom": "Castets-en-Dorthe"
+      },
+      {
+        "code": "33107",
+        "nom": "Castillon-de-Castets"
+      }
+    ]
+  },
+  {
+    "code": "33268",
+    "nom": "Margaux-Cantenac",
+    "anciennesCommunes": [
+      {
+        "code": "33091",
+        "nom": "Cantenac"
+      },
+      {
+        "code": "33268",
+        "nom": "Margaux"
+      }
+    ]
+  },
+  {
+    "code": "33380",
+    "nom": "Val-de-Livenne",
+    "anciennesCommunes": [
+      {
+        "code": "33267",
+        "nom": "Marcillac"
+      },
+      {
+        "code": "33380",
+        "nom": "Saint-Caprais-de-Blaye"
+      }
+    ]
+  },
+  {
+    "code": "34144",
+    "nom": "Lunas-les-Châteaux",
+    "anciennesCommunes": [
+      {
+        "code": "34093",
+        "nom": "Dio-et-Valquières"
+      },
+      {
+        "code": "34144",
+        "nom": "Lunas"
+      }
+    ]
+  },
+  {
+    "code": "34246",
+    "nom": "Entre-Vignes",
+    "anciennesCommunes": [
+      {
+        "code": "34246",
+        "nom": "Saint-Christol"
+      },
+      {
+        "code": "34330",
+        "nom": "Vérargues"
+      }
+    ]
+  },
+  {
+    "code": "35004",
+    "nom": "Val-Couesnon",
+    "anciennesCommunes": [
+      {
+        "code": "35004",
+        "nom": "Antrain"
+      },
+      {
+        "code": "35113",
+        "nom": "La Fontenelle"
+      },
+      {
+        "code": "35303",
+        "nom": "Saint-Ouen-la-Rouërie"
+      },
+      {
+        "code": "35341",
+        "nom": "Tremblay"
+      }
+    ]
+  },
+  {
+    "code": "35060",
+    "nom": "La Chapelle du Lou du Lac",
+    "anciennesCommunes": [
+      {
+        "code": "35060",
+        "nom": "La Chapelle-du-Lou"
+      },
+      {
+        "code": "35158",
+        "nom": "Le Lou-du-Lac"
+      }
+    ]
+  },
+  {
+    "code": "35062",
+    "nom": "La Chapelle-Fleurigné",
+    "anciennesCommunes": [
+      {
+        "code": "35062",
+        "nom": "La Chapelle-Janson"
+      },
+      {
+        "code": "35112",
+        "nom": "Fleurigné"
+      }
+    ]
+  },
+  {
+    "code": "35068",
+    "nom": "Châteaubourg",
+    "anciennesCommunes": [
+      {
+        "code": "35068",
+        "nom": "Châteaubourg"
+      }
+    ]
+  },
+  {
+    "code": "35069",
+    "nom": "Châteaugiron",
+    "anciennesCommunes": [
+      {
+        "code": "35069",
+        "nom": "Châteaugiron"
+      },
+      {
+        "code": "35209",
+        "nom": "Ossé"
+      },
+      {
+        "code": "35254",
+        "nom": "Saint-Aubin-du-Pavail"
+      }
+    ]
+  },
+  {
+    "code": "35130",
+    "nom": "Hédé-Bazouges",
+    "anciennesCommunes": [
+      {
+        "code": "35130",
+        "nom": "Hédé"
+      }
+    ]
+  },
+  {
+    "code": "35163",
+    "nom": "Luitré-Dompierre",
+    "anciennesCommunes": [
+      {
+        "code": "35100",
+        "nom": "Dompierre-du-Chemin"
+      },
+      {
+        "code": "35163",
+        "nom": "Luitré"
+      }
+    ]
+  },
+  {
+    "code": "35168",
+    "nom": "Val d'Anast",
+    "anciennesCommunes": [
+      {
+        "code": "35048",
+        "nom": "Campel"
+      },
+      {
+        "code": "35168",
+        "nom": "Maure-de-Bretagne"
+      }
+    ]
+  },
+  {
+    "code": "35176",
+    "nom": "Guipry-Messac",
+    "anciennesCommunes": [
+      {
+        "code": "35129",
+        "nom": "Guipry"
+      },
+      {
+        "code": "35176",
+        "nom": "Messac"
+      }
+    ]
+  },
+  {
+    "code": "35184",
+    "nom": "Montauban-de-Bretagne",
+    "anciennesCommunes": [
+      {
+        "code": "35184",
+        "nom": "Montauban-de-Bretagne"
+      },
+      {
+        "code": "35301",
+        "nom": "Saint-M'Hervon"
+      }
+    ]
+  },
+  {
+    "code": "35191",
+    "nom": "Les Portes du Coglais",
+    "anciennesCommunes": [
+      {
+        "code": "35083",
+        "nom": "Coglès"
+      },
+      {
+        "code": "35191",
+        "nom": "Montours"
+      },
+      {
+        "code": "35323",
+        "nom": "La Selle-en-Coglès"
+      }
+    ]
+  },
+  {
+    "code": "35220",
+    "nom": "Piré-Chancé",
+    "anciennesCommunes": [
+      {
+        "code": "35053",
+        "nom": "Chancé"
+      },
+      {
+        "code": "35220",
+        "nom": "Piré-sur-Seiche"
+      }
+    ]
+  },
+  {
+    "code": "35257",
+    "nom": "Maen Roch",
+    "anciennesCommunes": [
+      {
+        "code": "35257",
+        "nom": "Saint-Brice-en-Coglès"
+      },
+      {
+        "code": "35267",
+        "nom": "Saint-Étienne-en-Coglès"
+      }
+    ]
+  },
+  {
+    "code": "35282",
+    "nom": "Rives-du-Couesnon",
+    "anciennesCommunes": [
+      {
+        "code": "35269",
+        "nom": "Saint-Georges-de-Chesné"
+      },
+      {
+        "code": "35282",
+        "nom": "Saint-Jean-sur-Couesnon"
+      },
+      {
+        "code": "35293",
+        "nom": "Saint-Marc-sur-Couesnon"
+      },
+      {
+        "code": "35348",
+        "nom": "Vendel"
+      }
+    ]
+  },
+  {
+    "code": "35292",
+    "nom": "Saint-Marc-le-Blanc",
+    "anciennesCommunes": [
+      {
+        "code": "35011",
+        "nom": "Baillé"
+      },
+      {
+        "code": "35292",
+        "nom": "Saint-Marc-le-Blanc"
+      }
+    ]
+  },
+  {
+    "code": "35308",
+    "nom": "Mesnil-Roc'h",
+    "anciennesCommunes": [
+      {
+        "code": "35147",
+        "nom": "Lanhélin"
+      },
+      {
+        "code": "35308",
+        "nom": "Saint-Pierre-de-Plesguen"
+      },
+      {
+        "code": "35344",
+        "nom": "Tressé"
+      }
+    ]
+  },
+  {
+    "code": "36093",
+    "nom": "Levroux",
+    "anciennesCommunes": [
+      {
+        "code": "36093",
+        "nom": "Levroux"
+      },
+      {
+        "code": "36201",
+        "nom": "Saint-Martin-de-Lamps"
+      },
+      {
+        "code": "36206",
+        "nom": "Saint-Pierre-de-Lamps"
+      }
+    ]
+  },
+  {
+    "code": "36202",
+    "nom": "Saint-Maur",
+    "anciennesCommunes": [
+      {
+        "code": "36202",
+        "nom": "Saint-Maur"
+      },
+      {
+        "code": "36245",
+        "nom": "Villers-les-Ormes"
+      }
+    ]
+  },
+  {
+    "code": "36229",
+    "nom": "Val-Fouzon",
+    "anciennesCommunes": [
+      {
+        "code": "36151",
+        "nom": "Parpeçay"
+      },
+      {
+        "code": "36183",
+        "nom": "Sainte-Cécile"
+      },
+      {
+        "code": "36229",
+        "nom": "Varennes-sur-Fouzon"
+      }
+    ]
+  },
+  {
+    "code": "36244",
+    "nom": "Villentrois-Faverolles-en-Berry",
+    "anciennesCommunes": [
+      {
+        "code": "36072",
+        "nom": "Faverolles-en-Berry"
+      },
+      {
+        "code": "36244",
+        "nom": "Villentrois"
+      }
+    ]
+  },
+  {
+    "code": "37021",
+    "nom": "Beaumont-Louestault",
+    "anciennesCommunes": [
+      {
+        "code": "37021",
+        "nom": "Beaumont-la-Ronce"
+      },
+      {
+        "code": "37135",
+        "nom": "Louestault"
+      }
+    ]
+  },
+  {
+    "code": "37123",
+    "nom": "Langeais",
+    "anciennesCommunes": [
+      {
+        "code": "37102",
+        "nom": "Les Essards"
+      },
+      {
+        "code": "37123",
+        "nom": "Langeais"
+      }
+    ]
+  },
+  {
+    "code": "37232",
+    "nom": "Coteaux-sur-Loire",
+    "anciennesCommunes": [
+      {
+        "code": "37120",
+        "nom": "Ingrandes-de-Touraine"
+      },
+      {
+        "code": "37227",
+        "nom": "Saint-Michel-sur-Loire"
+      },
+      {
+        "code": "37232",
+        "nom": "Saint-Patrice"
+      }
+    ]
+  },
+  {
+    "code": "37254",
+    "nom": "Tauxigny-Saint-Bauld",
+    "anciennesCommunes": [
+      {
+        "code": "37209",
+        "nom": "Saint-Bauld"
+      },
+      {
+        "code": "37254",
+        "nom": "Tauxigny"
+      }
+    ]
+  },
+  {
+    "code": "38001",
+    "nom": "Les Abrets en Dauphiné",
+    "anciennesCommunes": [
+      {
+        "code": "38001",
+        "nom": "Les Abrets"
+      },
+      {
+        "code": "38028",
+        "nom": "La Bâtie-Divisin"
+      },
+      {
+        "code": "38165",
+        "nom": "Fitilieu"
+      }
+    ]
+  },
+  {
+    "code": "38022",
+    "nom": "Les Avenières Veyrins-Thuellin",
+    "anciennesCommunes": [
+      {
+        "code": "38022",
+        "nom": "Les Avenières"
+      },
+      {
+        "code": "38541",
+        "nom": "Veyrins-Thuellin"
+      }
+    ]
+  },
+  {
+    "code": "38073",
+    "nom": "Chantepérier",
+    "anciennesCommunes": [
+      {
+        "code": "38073",
+        "nom": "Chantelouve"
+      },
+      {
+        "code": "38302",
+        "nom": "Le Périer"
+      }
+    ]
+  },
+  {
+    "code": "38085",
+    "nom": "Charvieu-Chavagneux",
+    "anciennesCommunes": [
+      {
+        "code": "38085",
+        "nom": "Charvieu-Chavagneux"
+      }
+    ]
+  },
+  {
+    "code": "38152",
+    "nom": "Eclose-Badinières",
+    "anciennesCommunes": [
+      {
+        "code": "38024",
+        "nom": "Badinières"
+      },
+      {
+        "code": "38152",
+        "nom": "Eclose"
+      }
+    ]
+  },
+  {
+    "code": "38163",
+    "nom": "Le Haut-Bréda",
+    "anciennesCommunes": [
+      {
+        "code": "38163",
+        "nom": "La Ferrière"
+      },
+      {
+        "code": "38306",
+        "nom": "Pinsot"
+      }
+    ]
+  },
+  {
+    "code": "38225",
+    "nom": "Autrans-Méaudre en Vercors",
+    "anciennesCommunes": [
+      {
+        "code": "38021",
+        "nom": "Autrans"
+      },
+      {
+        "code": "38225",
+        "nom": "Méaudre"
+      }
+    ]
+  },
+  {
+    "code": "38253",
+    "nom": "Les Deux Alpes",
+    "anciennesCommunes": [
+      {
+        "code": "38253",
+        "nom": "Mont-de-Lans"
+      },
+      {
+        "code": "38534",
+        "nom": "Vénosc"
+      }
+    ]
+  },
+  {
+    "code": "38284",
+    "nom": "Ornacieux-Balbins",
+    "anciennesCommunes": [
+      {
+        "code": "38025",
+        "nom": "Balbins"
+      },
+      {
+        "code": "38284",
+        "nom": "Ornacieux"
+      }
+    ]
+  },
+  {
+    "code": "38292",
+    "nom": "Villages du Lac de Paladru",
+    "anciennesCommunes": [
+      {
+        "code": "38292",
+        "nom": "Paladru"
+      },
+      {
+        "code": "38305",
+        "nom": "Le Pin"
+      }
+    ]
+  },
+  {
+    "code": "38297",
+    "nom": "Arandon-Passins",
+    "anciennesCommunes": [
+      {
+        "code": "38014",
+        "nom": "Arandon"
+      },
+      {
+        "code": "38297",
+        "nom": "Passins"
+      }
+    ]
+  },
+  {
+    "code": "38348",
+    "nom": "Ruy-Montceau",
+    "anciennesCommunes": [
+      {
+        "code": "38348",
+        "nom": "Ruy"
+      }
+    ]
+  },
+  {
+    "code": "38359",
+    "nom": "Saint Antoine l'Abbaye",
+    "anciennesCommunes": [
+      {
+        "code": "38145",
+        "nom": "Dionay"
+      },
+      {
+        "code": "38359",
+        "nom": "Saint-Antoine-l'Abbaye"
+      }
+    ]
+  },
+  {
+    "code": "38395",
+    "nom": "Plateau-des-Petites-Roches",
+    "anciennesCommunes": [
+      {
+        "code": "38367",
+        "nom": "Saint-Bernard"
+      },
+      {
+        "code": "38395",
+        "nom": "Saint-Hilaire"
+      },
+      {
+        "code": "38435",
+        "nom": "Saint-Pancrasse"
+      }
+    ]
+  },
+  {
+    "code": "38407",
+    "nom": "La Sure en Chartreuse",
+    "anciennesCommunes": [
+      {
+        "code": "38312",
+        "nom": "Pommiers-la-Placette"
+      },
+      {
+        "code": "38407",
+        "nom": "Saint-Julien-de-Raz"
+      }
+    ]
+  },
+  {
+    "code": "38439",
+    "nom": "Crêts en Belledonne",
+    "anciennesCommunes": [
+      {
+        "code": "38262",
+        "nom": "Morêtel-de-Mailles"
+      },
+      {
+        "code": "38439",
+        "nom": "Saint-Pierre-d'Allevard"
+      }
+    ]
+  },
+  {
+    "code": "38456",
+    "nom": "Châtel-en-Trièves",
+    "anciennesCommunes": [
+      {
+        "code": "38125",
+        "nom": "Cordéac"
+      },
+      {
+        "code": "38456",
+        "nom": "Saint-Sébastien"
+      }
+    ]
+  },
+  {
+    "code": "38479",
+    "nom": "Porte-des-Bonnevaux",
+    "anciennesCommunes": [
+      {
+        "code": "38016",
+        "nom": "Arzay"
+      },
+      {
+        "code": "38121",
+        "nom": "Commelle"
+      },
+      {
+        "code": "38274",
+        "nom": "Nantoin"
+      },
+      {
+        "code": "38479",
+        "nom": "Semons"
+      }
+    ]
+  },
+  {
+    "code": "38560",
+    "nom": "Val-de-Virieu",
+    "anciennesCommunes": [
+      {
+        "code": "38293",
+        "nom": "Panissage"
+      },
+      {
+        "code": "38560",
+        "nom": "Virieu"
+      }
+    ]
+  },
+  {
+    "code": "39016",
+    "nom": "Arinthod",
+    "anciennesCommunes": [
+      {
+        "code": "39016",
+        "nom": "Arinthod"
+      },
+      {
+        "code": "39148",
+        "nom": "Chisséria"
+      }
+    ]
+  },
+  {
+    "code": "39017",
+    "nom": "Arlay",
+    "anciennesCommunes": [
+      {
+        "code": "39017",
+        "nom": "Arlay"
+      },
+      {
+        "code": "39482",
+        "nom": "Saint-Germain-lès-Arlay"
+      }
+    ]
+  },
+  {
+    "code": "39018",
+    "nom": "Aromas",
+    "anciennesCommunes": [
+      {
+        "code": "39018",
+        "nom": "Aromas"
+      },
+      {
+        "code": "39566",
+        "nom": "Villeneuve-lès-Charnod"
+      }
+    ]
+  },
+  {
+    "code": "39021",
+    "nom": "La Chailleuse",
+    "anciennesCommunes": [
+      {
+        "code": "39021",
+        "nom": "Arthenas"
+      },
+      {
+        "code": "39215",
+        "nom": "Essia"
+      },
+      {
+        "code": "39488",
+        "nom": "Saint-Laurent-la-Roche"
+      },
+      {
+        "code": "39544",
+        "nom": "Varessia"
+      }
+    ]
+  },
+  {
+    "code": "39043",
+    "nom": "Beaufort-Orbagna",
+    "anciennesCommunes": [
+      {
+        "code": "39043",
+        "nom": "Beaufort"
+      },
+      {
+        "code": "39395",
+        "nom": "Orbagna"
+      }
+    ]
+  },
+  {
+    "code": "39130",
+    "nom": "Nanchez",
+    "anciennesCommunes": [
+      {
+        "code": "39130",
+        "nom": "Chaux-des-Prés"
+      },
+      {
+        "code": "39417",
+        "nom": "Les Piards"
+      },
+      {
+        "code": "39442",
+        "nom": "Prénovel"
+      },
+      {
+        "code": "39562",
+        "nom": "Villard-sur-Bienne"
+      }
+    ]
+  },
+  {
+    "code": "39137",
+    "nom": "Saint-Hymetière-sur-Valouse",
+    "anciennesCommunes": [
+      {
+        "code": "39089",
+        "nom": "Cézia"
+      },
+      {
+        "code": "39137",
+        "nom": "Chemilla"
+      },
+      {
+        "code": "39287",
+        "nom": "Lavans-sur-Valouse"
+      },
+      {
+        "code": "39483",
+        "nom": "Saint-Hymetière"
+      }
+    ]
+  },
+  {
+    "code": "39177",
+    "nom": "Hauteroche",
+    "anciennesCommunes": [
+      {
+        "code": "39177",
+        "nom": "Crançot"
+      },
+      {
+        "code": "39260",
+        "nom": "Granges-sur-Baume"
+      },
+      {
+        "code": "39332",
+        "nom": "Mirebel"
+      }
+    ]
+  },
+  {
+    "code": "39190",
+    "nom": "Dampierre",
+    "anciennesCommunes": [
+      {
+        "code": "39190",
+        "nom": "Dampierre"
+      },
+      {
+        "code": "39414",
+        "nom": "Le Petit-Mercey"
+      }
+    ]
+  },
+  {
+    "code": "39198",
+    "nom": "Dole",
+    "anciennesCommunes": [
+      {
+        "code": "39078",
+        "nom": "Brevans"
+      },
+      {
+        "code": "39198",
+        "nom": "Dole"
+      }
+    ]
+  },
+  {
+    "code": "39199",
+    "nom": "Domblans",
+    "anciennesCommunes": [
+      {
+        "code": "39075",
+        "nom": "Bréry"
+      },
+      {
+        "code": "39199",
+        "nom": "Domblans"
+      }
+    ]
+  },
+  {
+    "code": "39209",
+    "nom": "Val-d'Épy",
+    "anciennesCommunes": [
+      {
+        "code": "39036",
+        "nom": "La Balme-d'Épy"
+      },
+      {
+        "code": "39209",
+        "nom": "Val d'Épy"
+      },
+      {
+        "code": "39226",
+        "nom": "Florentia"
+      },
+      {
+        "code": "39382",
+        "nom": "Nantey"
+      },
+      {
+        "code": "39509",
+        "nom": "Senaud"
+      }
+    ]
+  },
+  {
+    "code": "39258",
+    "nom": "Grande-Rivière Château",
+    "anciennesCommunes": [
+      {
+        "code": "39115",
+        "nom": "Château-des-Prés"
+      },
+      {
+        "code": "39258",
+        "nom": "Grande-Rivière"
+      }
+    ]
+  },
+  {
+    "code": "39273",
+    "nom": "Montlainsia",
+    "anciennesCommunes": [
+      {
+        "code": "39195",
+        "nom": "Dessia"
+      },
+      {
+        "code": "39273",
+        "nom": "Lains"
+      },
+      {
+        "code": "39347",
+        "nom": "Montagna-le-Templier"
+      }
+    ]
+  },
+  {
+    "code": "39286",
+    "nom": "Lavans-lès-Saint-Claude",
+    "anciennesCommunes": [
+      {
+        "code": "39286",
+        "nom": "Lavans-lès-Saint-Claude"
+      },
+      {
+        "code": "39438",
+        "nom": "Ponthoux"
+      },
+      {
+        "code": "39440",
+        "nom": "Pratz"
+      }
+    ]
+  },
+  {
+    "code": "39290",
+    "nom": "Valzin en Petite Montagne",
+    "anciennesCommunes": [
+      {
+        "code": "39123",
+        "nom": "Chatonnay"
+      },
+      {
+        "code": "39224",
+        "nom": "Fétigny"
+      },
+      {
+        "code": "39290",
+        "nom": "Légna"
+      },
+      {
+        "code": "39506",
+        "nom": "Savigna"
+      }
+    ]
+  },
+  {
+    "code": "39329",
+    "nom": "Mièges",
+    "anciennesCommunes": [
+      {
+        "code": "39213",
+        "nom": "Esserval-Combe"
+      },
+      {
+        "code": "39329",
+        "nom": "Mièges"
+      },
+      {
+        "code": "39340",
+        "nom": "Molpré"
+      }
+    ]
+  },
+  {
+    "code": "39331",
+    "nom": "Mignovillard",
+    "anciennesCommunes": [
+      {
+        "code": "39161",
+        "nom": "Communailles-en-Montagne"
+      },
+      {
+        "code": "39331",
+        "nom": "Mignovillard"
+      }
+    ]
+  },
+  {
+    "code": "39339",
+    "nom": "Chassal-Molinges",
+    "anciennesCommunes": [
+      {
+        "code": "39113",
+        "nom": "Chassal"
+      },
+      {
+        "code": "39339",
+        "nom": "Molinges"
+      }
+    ]
+  },
+  {
+    "code": "39368",
+    "nom": "Hauts de Bienne",
+    "anciennesCommunes": [
+      {
+        "code": "39294",
+        "nom": "Lézat"
+      },
+      {
+        "code": "39368",
+        "nom": "Morez"
+      },
+      {
+        "code": "39371",
+        "nom": "La Mouille"
+      }
+    ]
+  },
+  {
+    "code": "39378",
+    "nom": "Les Trois-Châteaux",
+    "anciennesCommunes": [
+      {
+        "code": "39023",
+        "nom": "L'Aubépin"
+      },
+      {
+        "code": "39135",
+        "nom": "Chazelles"
+      },
+      {
+        "code": "39378",
+        "nom": "Nanc-lès-Saint-Amour"
+      },
+      {
+        "code": "39484",
+        "nom": "Saint-Jean-d'Étreux"
+      }
+    ]
+  },
+  {
+    "code": "39434",
+    "nom": "Poligny",
+    "anciennesCommunes": [
+      {
+        "code": "39434",
+        "nom": "Poligny"
+      },
+      {
+        "code": "39548",
+        "nom": "Vaux-sur-Poligny"
+      }
+    ]
+  },
+  {
+    "code": "39478",
+    "nom": "Saint-Claude",
+    "anciennesCommunes": [
+      {
+        "code": "39478",
+        "nom": "Saint-Claude"
+      }
+    ]
+  },
+  {
+    "code": "39485",
+    "nom": "Val Suran",
+    "anciennesCommunes": [
+      {
+        "code": "39069",
+        "nom": "Bourcia"
+      },
+      {
+        "code": "39303",
+        "nom": "Louvenne"
+      },
+      {
+        "code": "39485",
+        "nom": "Saint-Julien"
+      },
+      {
+        "code": "39564",
+        "nom": "Villechantria"
+      }
+    ]
+  },
+  {
+    "code": "39491",
+    "nom": "Coteaux du Lizon",
+    "anciennesCommunes": [
+      {
+        "code": "39186",
+        "nom": "Cuttura"
+      },
+      {
+        "code": "39491",
+        "nom": "Saint-Lupicin"
+      }
+    ]
+  },
+  {
+    "code": "39510",
+    "nom": "Septmoncel les Molunes",
+    "anciennesCommunes": [
+      {
+        "code": "39341",
+        "nom": "Les Molunes"
+      },
+      {
+        "code": "39510",
+        "nom": "Septmoncel"
+      }
+    ]
+  },
+  {
+    "code": "39530",
+    "nom": "Thoirette-Coisia",
+    "anciennesCommunes": [
+      {
+        "code": "39158",
+        "nom": "Coisia"
+      },
+      {
+        "code": "39530",
+        "nom": "Thoirette"
+      }
+    ]
+  },
+  {
+    "code": "39537",
+    "nom": "Trenal",
+    "anciennesCommunes": [
+      {
+        "code": "39309",
+        "nom": "Mallerey"
+      },
+      {
+        "code": "39537",
+        "nom": "Trenal"
+      }
+    ]
+  },
+  {
+    "code": "39576",
+    "nom": "Val-Sonnette",
+    "anciennesCommunes": [
+      {
+        "code": "39064",
+        "nom": "Bonnaud"
+      },
+      {
+        "code": "39264",
+        "nom": "Grusse"
+      },
+      {
+        "code": "39474",
+        "nom": "Sainte-Agnès"
+      },
+      {
+        "code": "39549",
+        "nom": "Vercia"
+      },
+      {
+        "code": "39576",
+        "nom": "Vincelles"
+      }
+    ]
+  },
+  {
+    "code": "39577",
+    "nom": "Vincent-Froideville",
+    "anciennesCommunes": [
+      {
+        "code": "39243",
+        "nom": "Froideville"
+      },
+      {
+        "code": "39577",
+        "nom": "Vincent"
+      }
+    ]
+  },
+  {
+    "code": "39583",
+    "nom": "Vosbles-Valfin",
+    "anciennesCommunes": [
+      {
+        "code": "39542",
+        "nom": "Valfin-sur-Valouse"
+      },
+      {
+        "code": "39583",
+        "nom": "Vosbles"
+      }
+    ]
+  },
+  {
+    "code": "40197",
+    "nom": "Morcenx-la-Nouvelle",
+    "anciennesCommunes": [
+      {
+        "code": "40009",
+        "nom": "Arjuzanx"
+      },
+      {
+        "code": "40107",
+        "nom": "Garrosse"
+      },
+      {
+        "code": "40197",
+        "nom": "Morcenx"
+      },
+      {
+        "code": "40302",
+        "nom": "Sindères"
+      }
+    ]
+  },
+  {
+    "code": "40243",
+    "nom": "Rion-des-Landes",
+    "anciennesCommunes": [
+      {
+        "code": "40048",
+        "nom": "Boos"
+      },
+      {
+        "code": "40243",
+        "nom": "Rion-des-Landes"
+      }
+    ]
+  },
+  {
+    "code": "41055",
+    "nom": "Valloire-sur-Cisse",
+    "anciennesCommunes": [
+      {
+        "code": "41055",
+        "nom": "Chouzy-sur-Cisse"
+      },
+      {
+        "code": "41064",
+        "nom": "Coulanges"
+      },
+      {
+        "code": "41240",
+        "nom": "Seillac"
+      }
+    ]
+  },
+  {
+    "code": "41059",
+    "nom": "Le Controis-en-Sologne",
+    "anciennesCommunes": [
+      {
+        "code": "41059",
+        "nom": "Contres"
+      },
+      {
+        "code": "41082",
+        "nom": "Feings"
+      },
+      {
+        "code": "41092",
+        "nom": "Fougères-sur-Bièvre"
+      },
+      {
+        "code": "41170",
+        "nom": "Ouchamps"
+      },
+      {
+        "code": "41257",
+        "nom": "Thenay"
+      }
+    ]
+  },
+  {
+    "code": "41070",
+    "nom": "Vallée-de-Ronsard",
+    "anciennesCommunes": [
+      {
+        "code": "41070",
+        "nom": "Couture-sur-Loir"
+      },
+      {
+        "code": "41263",
+        "nom": "Tréhet"
+      }
+    ]
+  },
+  {
+    "code": "41142",
+    "nom": "Valencisse",
+    "anciennesCommunes": [
+      {
+        "code": "41033",
+        "nom": "Chambon-sur-Cisse"
+      },
+      {
+        "code": "41142",
+        "nom": "Molineuf"
+      },
+      {
+        "code": "41169",
+        "nom": "Orchaise"
+      }
+    ]
+  },
+  {
+    "code": "41151",
+    "nom": "Montrichard Val de Cher",
+    "anciennesCommunes": [
+      {
+        "code": "41023",
+        "nom": "Bourré"
+      },
+      {
+        "code": "41151",
+        "nom": "Montrichard"
+      }
+    ]
+  },
+  {
+    "code": "41167",
+    "nom": "Veuzain-sur-Loire",
+    "anciennesCommunes": [
+      {
+        "code": "41167",
+        "nom": "Onzain"
+      },
+      {
+        "code": "41272",
+        "nom": "Veuves"
+      }
+    ]
+  },
+  {
+    "code": "41171",
+    "nom": "Oucques La Nouvelle",
+    "anciennesCommunes": [
+      {
+        "code": "41011",
+        "nom": "Baigneaux"
+      },
+      {
+        "code": "41015",
+        "nom": "Beauvilliers"
+      },
+      {
+        "code": "41171",
+        "nom": "Oucques"
+      },
+      {
+        "code": "41210",
+        "nom": "Sainte-Gemmes"
+      }
+    ]
+  },
+  {
+    "code": "41173",
+    "nom": "Beauce la Romaine",
+    "anciennesCommunes": [
+      {
+        "code": "41056",
+        "nom": "La Colombe"
+      },
+      {
+        "code": "41133",
+        "nom": "Membrolles"
+      },
+      {
+        "code": "41173",
+        "nom": "Ouzouer-le-Marché"
+      },
+      {
+        "code": "41183",
+        "nom": "Prénouvellon"
+      },
+      {
+        "code": "41244",
+        "nom": "Semerville"
+      },
+      {
+        "code": "41264",
+        "nom": "Tripleville"
+      },
+      {
+        "code": "41270",
+        "nom": "Verdes"
+      }
+    ]
+  },
+  {
+    "code": "41248",
+    "nom": "Couëtron-au-Perche",
+    "anciennesCommunes": [
+      {
+        "code": "41005",
+        "nom": "Arville"
+      },
+      {
+        "code": "41165",
+        "nom": "Oigny"
+      },
+      {
+        "code": "41197",
+        "nom": "Saint-Agil"
+      },
+      {
+        "code": "41202",
+        "nom": "Saint-Avit"
+      },
+      {
+        "code": "41248",
+        "nom": "Souday"
+      }
+    ]
+  },
+  {
+    "code": "42005",
+    "nom": "Andrézieux-Bouthéon",
+    "anciennesCommunes": [
+      {
+        "code": "42005",
+        "nom": "Andrézieux-Bouthéon"
+      }
+    ]
+  },
+  {
+    "code": "42039",
+    "nom": "Chalmazel-Jeansagnière",
+    "anciennesCommunes": [
+      {
+        "code": "42039",
+        "nom": "Chalmazel"
+      },
+      {
+        "code": "42114",
+        "nom": "Jeansagnière"
+      }
+    ]
+  },
+  {
+    "code": "42084",
+    "nom": "Solore-en-Forez",
+    "anciennesCommunes": [
+      {
+        "code": "42084",
+        "nom": "Débats-Rivière-d'Orpra"
+      },
+      {
+        "code": "42109",
+        "nom": "L'Hôpital-sous-Rochefort"
+      },
+      {
+        "code": "42252",
+        "nom": "Saint-Laurent-Rochefort"
+      }
+    ]
+  },
+  {
+    "code": "42147",
+    "nom": "Montbrison",
+    "anciennesCommunes": [
+      {
+        "code": "42147",
+        "nom": "Montbrison"
+      }
+    ]
+  },
+  {
+    "code": "42217",
+    "nom": "La Côte-Saint-Didier",
+    "anciennesCommunes": [
+      {
+        "code": "42072",
+        "nom": "La Côte-en-Couzan"
+      },
+      {
+        "code": "42217",
+        "nom": "Saint-Didier-sur-Rochefort"
+      }
+    ]
+  },
+  {
+    "code": "42245",
+    "nom": "Vêtre-sur-Anzon",
+    "anciennesCommunes": [
+      {
+        "code": "42245",
+        "nom": "Saint-Julien-la-Vêtre"
+      },
+      {
+        "code": "42291",
+        "nom": "Saint-Thurin"
+      }
+    ]
+  },
+  {
+    "code": "42268",
+    "nom": "Vézelin-sur-Loire",
+    "anciennesCommunes": [
+      {
+        "code": "42004",
+        "nom": "Amions"
+      },
+      {
+        "code": "42082",
+        "nom": "Dancé"
+      },
+      {
+        "code": "42268",
+        "nom": "Saint-Paul-de-Vézelin"
+      }
+    ]
+  },
+  {
+    "code": "43090",
+    "nom": "Esplantas-Vazeilles",
+    "anciennesCommunes": [
+      {
+        "code": "43090",
+        "nom": "Esplantas"
+      },
+      {
+        "code": "43255",
+        "nom": "Vazeilles-près-Saugues"
+      }
+    ]
+  },
+  {
+    "code": "43221",
+    "nom": "Saint-Privat-d'Allier",
+    "anciennesCommunes": [
+      {
+        "code": "43176",
+        "nom": "Saint-Didier-d'Allier"
+      },
+      {
+        "code": "43221",
+        "nom": "Saint-Privat-d'Allier"
+      }
+    ]
+  },
+  {
+    "code": "43245",
+    "nom": "Thoras",
+    "anciennesCommunes": [
+      {
+        "code": "43081",
+        "nom": "Croisances"
+      },
+      {
+        "code": "43245",
+        "nom": "Thoras"
+      }
+    ]
+  },
+  {
+    "code": "44003",
+    "nom": "Ancenis-Saint-Géréon",
+    "anciennesCommunes": [
+      {
+        "code": "44003",
+        "nom": "Ancenis"
+      },
+      {
+        "code": "44160",
+        "nom": "Saint-Géréon"
+      }
+    ]
+  },
+  {
+    "code": "44005",
+    "nom": "Chaumes-en-Retz",
+    "anciennesCommunes": [
+      {
+        "code": "44005",
+        "nom": "Arthon-en-Retz"
+      },
+      {
+        "code": "44040",
+        "nom": "Chéméré"
+      }
+    ]
+  },
+  {
+    "code": "44021",
+    "nom": "Villeneuve-en-Retz",
+    "anciennesCommunes": [
+      {
+        "code": "44021",
+        "nom": "Bourgneuf-en-Retz"
+      },
+      {
+        "code": "44059",
+        "nom": "Fresnay-en-Retz"
+      }
+    ]
+  },
+  {
+    "code": "44029",
+    "nom": "Divatte-sur-Loire",
+    "anciennesCommunes": [
+      {
+        "code": "44008",
+        "nom": "Barbechat"
+      },
+      {
+        "code": "44029",
+        "nom": "La Chapelle-Basse-Mer"
+      }
+    ]
+  },
+  {
+    "code": "44087",
+    "nom": "Machecoul-Saint-Même",
+    "anciennesCommunes": [
+      {
+        "code": "44087",
+        "nom": "Machecoul"
+      },
+      {
+        "code": "44181",
+        "nom": "Saint-Même-le-Tenu"
+      }
+    ]
+  },
+  {
+    "code": "44163",
+    "nom": "Vair-sur-Loire",
+    "anciennesCommunes": [
+      {
+        "code": "44004",
+        "nom": "Anetz"
+      },
+      {
+        "code": "44163",
+        "nom": "Saint-Herblon"
+      }
+    ]
+  },
+  {
+    "code": "44180",
+    "nom": "Vallons-de-l'Erdre",
+    "anciennesCommunes": [
+      {
+        "code": "44017",
+        "nom": "Bonnœuvre"
+      },
+      {
+        "code": "44093",
+        "nom": "Maumusson"
+      },
+      {
+        "code": "44180",
+        "nom": "Saint-Mars-la-Jaille"
+      },
+      {
+        "code": "44191",
+        "nom": "Saint-Sulpice-des-Landes"
+      },
+      {
+        "code": "44219",
+        "nom": "Vritz"
+      },
+      {
+        "code": "44225",
+        "nom": "Freigné"
+      }
+    ]
+  },
+  {
+    "code": "44213",
+    "nom": "Loireauxence",
+    "anciennesCommunes": [
+      {
+        "code": "44011",
+        "nom": "Belligné"
+      },
+      {
+        "code": "44034",
+        "nom": "La Chapelle-Saint-Sauveur"
+      },
+      {
+        "code": "44147",
+        "nom": "La Rouxière"
+      },
+      {
+        "code": "44213",
+        "nom": "Varades"
+      }
+    ]
+  },
+  {
+    "code": "45051",
+    "nom": "Bray-Saint-Aignan",
+    "anciennesCommunes": [
+      {
+        "code": "45051",
+        "nom": "Bray-en-Val"
+      },
+      {
+        "code": "45267",
+        "nom": "Saint-Aignan-des-Gués"
+      }
+    ]
+  },
+  {
+    "code": "45129",
+    "nom": "Douchy-Montcorbon",
+    "anciennesCommunes": [
+      {
+        "code": "45129",
+        "nom": "Douchy"
+      },
+      {
+        "code": "45211",
+        "nom": "Montcorbon"
+      }
+    ]
+  },
+  {
+    "code": "45191",
+    "nom": "Le Malesherbois",
+    "anciennesCommunes": [
+      {
+        "code": "45057",
+        "nom": "Labrosse"
+      },
+      {
+        "code": "45106",
+        "nom": "Coudray"
+      },
+      {
+        "code": "45190",
+        "nom": "Mainvilliers"
+      },
+      {
+        "code": "45191",
+        "nom": "Malesherbes"
+      },
+      {
+        "code": "45192",
+        "nom": "Manchecourt"
+      },
+      {
+        "code": "45221",
+        "nom": "Nangeville"
+      },
+      {
+        "code": "45236",
+        "nom": "Orveau-Bellesauve"
+      }
+    ]
+  },
+  {
+    "code": "45307",
+    "nom": "La Selle-sur-le-Bied",
+    "anciennesCommunes": [
+      {
+        "code": "45287",
+        "nom": "Saint-Loup-de-Gonois"
+      },
+      {
+        "code": "45307",
+        "nom": "La Selle-sur-le-Bied"
+      }
+    ]
+  },
+  {
+    "code": "46033",
+    "nom": "Porte-du-Quercy",
+    "anciennesCommunes": [
+      {
+        "code": "46033",
+        "nom": "Le Boulvé"
+      },
+      {
+        "code": "46099",
+        "nom": "Fargues"
+      },
+      {
+        "code": "46278",
+        "nom": "Saint-Matré"
+      },
+      {
+        "code": "46300",
+        "nom": "Saux"
+      }
+    ]
+  },
+  {
+    "code": "46063",
+    "nom": "Castelnau-Montratier",
+    "anciennesCommunes": [
+      {
+        "code": "46063",
+        "nom": "Castelnau-Montratier"
+      },
+      {
+        "code": "46248",
+        "nom": "Sainte-Alauzie"
+      }
+    ]
+  },
+  {
+    "code": "46083",
+    "nom": "Cressensac-Sarrazac",
+    "anciennesCommunes": [
+      {
+        "code": "46083",
+        "nom": "Cressensac"
+      },
+      {
+        "code": "46298",
+        "nom": "Sarrazac"
+      }
+    ]
+  },
+  {
+    "code": "46103",
+    "nom": "Saint-Paul-Flaugnac",
+    "anciennesCommunes": [
+      {
+        "code": "46103",
+        "nom": "Flaugnac"
+      },
+      {
+        "code": "46287",
+        "nom": "Saint-Paul-de-Loubressac"
+      }
+    ]
+  },
+  {
+    "code": "46138",
+    "nom": "Cœur de Causse",
+    "anciennesCommunes": [
+      {
+        "code": "46019",
+        "nom": "Beaumat"
+      },
+      {
+        "code": "46110",
+        "nom": "Fontanes-du-Causse"
+      },
+      {
+        "code": "46138",
+        "nom": "Labastide-Murat"
+      },
+      {
+        "code": "46291",
+        "nom": "Saint-Sauveur-la-Vallée"
+      },
+      {
+        "code": "46325",
+        "nom": "Vaillac"
+      }
+    ]
+  },
+  {
+    "code": "46156",
+    "nom": "Bellefont-La Rauze",
+    "anciennesCommunes": [
+      {
+        "code": "46077",
+        "nom": "Cours"
+      },
+      {
+        "code": "46156",
+        "nom": "Laroque-des-Arcs"
+      },
+      {
+        "code": "46327",
+        "nom": "Valroufié"
+      }
+    ]
+  },
+  {
+    "code": "46172",
+    "nom": "Pern-Lhospitalet",
+    "anciennesCommunes": [
+      {
+        "code": "46172",
+        "nom": "Lhospitalet"
+      },
+      {
+        "code": "46217",
+        "nom": "Pern"
+      }
+    ]
+  },
+  {
+    "code": "46201",
+    "nom": "Montcuq-en-Quercy-Blanc",
+    "anciennesCommunes": [
+      {
+        "code": "46025",
+        "nom": "Belmontet"
+      },
+      {
+        "code": "46166",
+        "nom": "Lebreil"
+      },
+      {
+        "code": "46201",
+        "nom": "Montcuq"
+      },
+      {
+        "code": "46261",
+        "nom": "Sainte-Croix"
+      },
+      {
+        "code": "46326",
+        "nom": "Valprionde"
+      }
+    ]
+  },
+  {
+    "code": "46232",
+    "nom": "Le Vignon-en-Quercy",
+    "anciennesCommunes": [
+      {
+        "code": "46067",
+        "nom": "Cazillac"
+      },
+      {
+        "code": "46232",
+        "nom": "Les Quatre-Routes-du-Lot"
+      }
+    ]
+  },
+  {
+    "code": "46252",
+    "nom": "Les Pechs du Vers",
+    "anciennesCommunes": [
+      {
+        "code": "46252",
+        "nom": "Saint-Cernin"
+      },
+      {
+        "code": "46275",
+        "nom": "Saint-Martin-de-Vers"
+      }
+    ]
+  },
+  {
+    "code": "46262",
+    "nom": "Lendou-en-Quercy",
+    "anciennesCommunes": [
+      {
+        "code": "46158",
+        "nom": "Lascabanes"
+      },
+      {
+        "code": "46262",
+        "nom": "Saint-Cyprien"
+      },
+      {
+        "code": "46274",
+        "nom": "Saint-Laurent-Lolmie"
+      }
+    ]
+  },
+  {
+    "code": "46263",
+    "nom": "Barguelonne-en-Quercy",
+    "anciennesCommunes": [
+      {
+        "code": "46014",
+        "nom": "Bagat-en-Quercy"
+      },
+      {
+        "code": "46263",
+        "nom": "Saint-Daunès"
+      },
+      {
+        "code": "46285",
+        "nom": "Saint-Pantaléon"
+      }
+    ]
+  },
+  {
+    "code": "46268",
+    "nom": "Saint Géry-Vers",
+    "anciennesCommunes": [
+      {
+        "code": "46268",
+        "nom": "Saint-Géry"
+      },
+      {
+        "code": "46331",
+        "nom": "Vers"
+      }
+    ]
+  },
+  {
+    "code": "46311",
+    "nom": "Sousceyrac-en-Quercy",
+    "anciennesCommunes": [
+      {
+        "code": "46048",
+        "nom": "Calviac"
+      },
+      {
+        "code": "46071",
+        "nom": "Comiac"
+      },
+      {
+        "code": "46141",
+        "nom": "Lacam-d'Ourcet"
+      },
+      {
+        "code": "46150",
+        "nom": "Lamativie"
+      },
+      {
+        "code": "46311",
+        "nom": "Sousceyrac"
+      }
+    ]
+  },
+  {
+    "code": "48009",
+    "nom": "Peyre en Aubrac",
+    "anciennesCommunes": [
+      {
+        "code": "48009",
+        "nom": "Aumont-Aubrac"
+      },
+      {
+        "code": "48047",
+        "nom": "La Chaze-de-Peyre"
+      },
+      {
+        "code": "48060",
+        "nom": "Fau-de-Peyre"
+      },
+      {
+        "code": "48076",
+        "nom": "Javols"
+      },
+      {
+        "code": "48142",
+        "nom": "Sainte-Colombe-de-Peyre"
+      },
+      {
+        "code": "48183",
+        "nom": "Saint-Sauveur-de-Peyre"
+      }
+    ]
+  },
+  {
+    "code": "48017",
+    "nom": "Banassac-Canilhac",
+    "anciennesCommunes": [
+      {
+        "code": "48017",
+        "nom": "Banassac"
+      },
+      {
+        "code": "48033",
+        "nom": "Canilhac"
+      }
+    ]
+  },
+  {
+    "code": "48027",
+    "nom": "Mont Lozère et Goulet",
+    "anciennesCommunes": [
+      {
+        "code": "48014",
+        "nom": "Bagnols-les-Bains"
+      },
+      {
+        "code": "48023",
+        "nom": "Belvezet"
+      },
+      {
+        "code": "48027",
+        "nom": "Le Bleymard"
+      },
+      {
+        "code": "48040",
+        "nom": "Chasseradès"
+      },
+      {
+        "code": "48093",
+        "nom": "Mas-d'Orcières"
+      },
+      {
+        "code": "48164",
+        "nom": "Saint-Julien-du-Tournel"
+      }
+    ]
+  },
+  {
+    "code": "48038",
+    "nom": "Bel-Air-Val-d'Ance",
+    "anciennesCommunes": [
+      {
+        "code": "48038",
+        "nom": "Chambon-le-Château"
+      },
+      {
+        "code": "48184",
+        "nom": "Saint-Symphorien"
+      }
+    ]
+  },
+  {
+    "code": "48050",
+    "nom": "Bédouès-Cocurès",
+    "anciennesCommunes": [
+      {
+        "code": "48022",
+        "nom": "Bédouès"
+      },
+      {
+        "code": "48050",
+        "nom": "Cocurès"
+      }
+    ]
+  },
+  {
+    "code": "48061",
+    "nom": "Florac Trois Rivières",
+    "anciennesCommunes": [
+      {
+        "code": "48061",
+        "nom": "Florac"
+      },
+      {
+        "code": "48186",
+        "nom": "La Salle-Prunet"
+      }
+    ]
+  },
+  {
+    "code": "48087",
+    "nom": "Prinsuéjols-Malbouzon",
+    "anciennesCommunes": [
+      {
+        "code": "48087",
+        "nom": "Malbouzon"
+      },
+      {
+        "code": "48120",
+        "nom": "Prinsuéjols"
+      }
+    ]
+  },
+  {
+    "code": "48094",
+    "nom": "Massegros Causses Gorges",
+    "anciennesCommunes": [
+      {
+        "code": "48094",
+        "nom": "Le Massegros"
+      },
+      {
+        "code": "48125",
+        "nom": "Le Recoux"
+      },
+      {
+        "code": "48154",
+        "nom": "Saint-Georges-de-Lévéjac"
+      },
+      {
+        "code": "48180",
+        "nom": "Saint-Rome-de-Dolan"
+      },
+      {
+        "code": "48195",
+        "nom": "Les Vignes"
+      }
+    ]
+  },
+  {
+    "code": "48099",
+    "nom": "Bourgs sur Colagne",
+    "anciennesCommunes": [
+      {
+        "code": "48049",
+        "nom": "Chirac"
+      },
+      {
+        "code": "48099",
+        "nom": "Le Monastier-Pin-Moriès"
+      }
+    ]
+  },
+  {
+    "code": "48105",
+    "nom": "Naussac-Fontanes",
+    "anciennesCommunes": [
+      {
+        "code": "48062",
+        "nom": "Fontanes"
+      },
+      {
+        "code": "48105",
+        "nom": "Naussac"
+      }
+    ]
+  },
+  {
+    "code": "48116",
+    "nom": "Pont de Montvert - Sud Mont Lozère",
+    "anciennesCommunes": [
+      {
+        "code": "48066",
+        "nom": "Fraissinet-de-Lozère"
+      },
+      {
+        "code": "48116",
+        "nom": "Le Pont-de-Montvert"
+      },
+      {
+        "code": "48172",
+        "nom": "Saint-Maurice-de-Ventalon"
+      }
+    ]
+  },
+  {
+    "code": "48126",
+    "nom": "Lachamp-Ribennes",
+    "anciennesCommunes": [
+      {
+        "code": "48078",
+        "nom": "Lachamp"
+      },
+      {
+        "code": "48126",
+        "nom": "Ribennes"
+      }
+    ]
+  },
+  {
+    "code": "48127",
+    "nom": "Monts-de-Randon",
+    "anciennesCommunes": [
+      {
+        "code": "48057",
+        "nom": "Estables"
+      },
+      {
+        "code": "48127",
+        "nom": "Rieutort-de-Randon"
+      },
+      {
+        "code": "48133",
+        "nom": "Saint-Amans"
+      },
+      {
+        "code": "48189",
+        "nom": "Servières"
+      },
+      {
+        "code": "48197",
+        "nom": "La Villedieu"
+      }
+    ]
+  },
+  {
+    "code": "48139",
+    "nom": "Saint Bonnet-Laval",
+    "anciennesCommunes": [
+      {
+        "code": "48084",
+        "nom": "Laval-Atger"
+      },
+      {
+        "code": "48139",
+        "nom": "Saint-Bonnet-de-Montauroux"
+      }
+    ]
+  },
+  {
+    "code": "48146",
+    "nom": "Gorges du Tarn Causses",
+    "anciennesCommunes": [
+      {
+        "code": "48101",
+        "nom": "Montbrun"
+      },
+      {
+        "code": "48122",
+        "nom": "Quézac"
+      },
+      {
+        "code": "48146",
+        "nom": "Sainte-Enimie"
+      }
+    ]
+  },
+  {
+    "code": "48152",
+    "nom": "Ventalon en Cévennes",
+    "anciennesCommunes": [
+      {
+        "code": "48134",
+        "nom": "Saint-Andéol-de-Clerguemort"
+      },
+      {
+        "code": "48152",
+        "nom": "Saint-Frézal-de-Ventalon"
+      }
+    ]
+  },
+  {
+    "code": "48166",
+    "nom": "Cans et Cévennes",
+    "anciennesCommunes": [
+      {
+        "code": "48162",
+        "nom": "Saint-Julien-d'Arpaon"
+      },
+      {
+        "code": "48166",
+        "nom": "Saint-Laurent-de-Trèves"
+      }
+    ]
+  },
+  {
+    "code": "49003",
+    "nom": "Tuffalun",
+    "anciennesCommunes": [
+      {
+        "code": "49003",
+        "nom": "Ambillou-Château"
+      },
+      {
+        "code": "49181",
+        "nom": "Louerre"
+      },
+      {
+        "code": "49230",
+        "nom": "Noyant-la-Plaine"
+      }
+    ]
+  },
+  {
+    "code": "49018",
+    "nom": "Baugé-en-Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49018",
+        "nom": "Baugé"
+      },
+      {
+        "code": "49031",
+        "nom": "Bocé"
+      },
+      {
+        "code": "49079",
+        "nom": "Chartrené"
+      },
+      {
+        "code": "49097",
+        "nom": "Cheviré-le-Rouge"
+      },
+      {
+        "code": "49101",
+        "nom": "Clefs-Val d'Anjou"
+      },
+      {
+        "code": "49116",
+        "nom": "Cuon"
+      },
+      {
+        "code": "49128",
+        "nom": "Échemiré"
+      },
+      {
+        "code": "49143",
+        "nom": "Fougeré"
+      },
+      {
+        "code": "49157",
+        "nom": "Le Guédeniau"
+      },
+      {
+        "code": "49213",
+        "nom": "Montpollin"
+      },
+      {
+        "code": "49245",
+        "nom": "Pontigné"
+      },
+      {
+        "code": "49303",
+        "nom": "Saint-Martin-d'Arcé"
+      },
+      {
+        "code": "49315",
+        "nom": "Saint-Quentin-lès-Beaurepaire"
+      },
+      {
+        "code": "49372",
+        "nom": "Le Vieil-Baugé"
+      }
+    ]
+  },
+  {
+    "code": "49021",
+    "nom": "Beaufort-en-Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49021",
+        "nom": "Beaufort-en-Vallée"
+      },
+      {
+        "code": "49147",
+        "nom": "Gée"
+      }
+    ]
+  },
+  {
+    "code": "49023",
+    "nom": "Beaupréau-en-Mauges",
+    "anciennesCommunes": [
+      {
+        "code": "49006",
+        "nom": "Andrezé"
+      },
+      {
+        "code": "49023",
+        "nom": "Beaupréau"
+      },
+      {
+        "code": "49072",
+        "nom": "La Chapelle-du-Genêt"
+      },
+      {
+        "code": "49151",
+        "nom": "Gesté"
+      },
+      {
+        "code": "49162",
+        "nom": "Jallais"
+      },
+      {
+        "code": "49165",
+        "nom": "La Jubaudière"
+      },
+      {
+        "code": "49239",
+        "nom": "Le Pin-en-Mauges"
+      },
+      {
+        "code": "49243",
+        "nom": "La Poitevinière"
+      },
+      {
+        "code": "49312",
+        "nom": "Saint-Philbert-en-Mauges"
+      },
+      {
+        "code": "49375",
+        "nom": "Villedieu-la-Blouère"
+      }
+    ]
+  },
+  {
+    "code": "49029",
+    "nom": "Blaison-Saint-Sulpice",
+    "anciennesCommunes": [
+      {
+        "code": "49029",
+        "nom": "Blaison-Gohier"
+      },
+      {
+        "code": "49322",
+        "nom": "Saint-Sulpice"
+      }
+    ]
+  },
+  {
+    "code": "49050",
+    "nom": "Brissac Loire Aubance",
+    "anciennesCommunes": [
+      {
+        "code": "49001",
+        "nom": "Les Alleuds"
+      },
+      {
+        "code": "49050",
+        "nom": "Brissac-Quincé"
+      },
+      {
+        "code": "49078",
+        "nom": "Charcé-Saint-Ellier-sur-Aubance"
+      },
+      {
+        "code": "49091",
+        "nom": "Chemellier"
+      },
+      {
+        "code": "49115",
+        "nom": "Coutures"
+      },
+      {
+        "code": "49186",
+        "nom": "Luigné"
+      },
+      {
+        "code": "49317",
+        "nom": "Saint-Rémy-la-Varenne"
+      },
+      {
+        "code": "49318",
+        "nom": "Saint-Saturnin-sur-Loire"
+      },
+      {
+        "code": "49327",
+        "nom": "Saulgé-l'Hôpital"
+      },
+      {
+        "code": "49363",
+        "nom": "Vauchrétien"
+      }
+    ]
+  },
+  {
+    "code": "49060",
+    "nom": "Bellevigne-les-Châteaux",
+    "anciennesCommunes": [
+      {
+        "code": "49046",
+        "nom": "Brézé"
+      },
+      {
+        "code": "49060",
+        "nom": "Chacé"
+      },
+      {
+        "code": "49274",
+        "nom": "Saint-Cyr-en-Bourg"
+      }
+    ]
+  },
+  {
+    "code": "49067",
+    "nom": "Chenillé-Champteussé",
+    "anciennesCommunes": [
+      {
+        "code": "49067",
+        "nom": "Champteussé-sur-Baconne"
+      },
+      {
+        "code": "49095",
+        "nom": "Chenillé-Changé"
+      }
+    ]
+  },
+  {
+    "code": "49080",
+    "nom": "Les Hauts-d'Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49065",
+        "nom": "Les Hauts d'Anjou"
+      },
+      {
+        "code": "49080",
+        "nom": "Châteauneuf-sur-Sarthe"
+      }
+    ]
+  },
+  {
+    "code": "49086",
+    "nom": "Terranjou",
+    "anciennesCommunes": [
+      {
+        "code": "49086",
+        "nom": "Chavagnes"
+      },
+      {
+        "code": "49191",
+        "nom": "Martigné-Briand"
+      },
+      {
+        "code": "49227",
+        "nom": "Notre-Dame-d'Allençon"
+      }
+    ]
+  },
+  {
+    "code": "49092",
+    "nom": "Chemillé-en-Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49071",
+        "nom": "Chanzeaux"
+      },
+      {
+        "code": "49074",
+        "nom": "La Chapelle-Rousselin"
+      },
+      {
+        "code": "49092",
+        "nom": "Chemillé"
+      },
+      {
+        "code": "49111",
+        "nom": "Cossé-d'Anjou"
+      },
+      {
+        "code": "49153",
+        "nom": "Valanjou"
+      },
+      {
+        "code": "49169",
+        "nom": "La Jumellière"
+      },
+      {
+        "code": "49199",
+        "nom": "Melay"
+      },
+      {
+        "code": "49225",
+        "nom": "Neuvy-en-Mauges"
+      },
+      {
+        "code": "49268",
+        "nom": "Sainte-Christine"
+      },
+      {
+        "code": "49281",
+        "nom": "Saint-Georges-des-Gardes"
+      },
+      {
+        "code": "49300",
+        "nom": "Saint-Lézin"
+      },
+      {
+        "code": "49325",
+        "nom": "La Salle-de-Vihiers"
+      },
+      {
+        "code": "49351",
+        "nom": "La Tourlandry"
+      }
+    ]
+  },
+  {
+    "code": "49125",
+    "nom": "Doué-en-Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49047",
+        "nom": "Brigné"
+      },
+      {
+        "code": "49104",
+        "nom": "Concourson-sur-Layon"
+      },
+      {
+        "code": "49125",
+        "nom": "Doué-la-Fontaine"
+      },
+      {
+        "code": "49141",
+        "nom": "Forges"
+      },
+      {
+        "code": "49198",
+        "nom": "Meigné"
+      },
+      {
+        "code": "49207",
+        "nom": "Montfort"
+      },
+      {
+        "code": "49282",
+        "nom": "Saint-Georges-sur-Layon"
+      },
+      {
+        "code": "49365",
+        "nom": "Les Verchers-sur-Layon"
+      }
+    ]
+  },
+  {
+    "code": "49138",
+    "nom": "Les Bois d'Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49049",
+        "nom": "Brion"
+      },
+      {
+        "code": "49138",
+        "nom": "Fontaine-Guérin"
+      },
+      {
+        "code": "49280",
+        "nom": "Saint-Georges-du-Bois"
+      }
+    ]
+  },
+  {
+    "code": "49160",
+    "nom": "Ingrandes-le-Fresne-sur-Loire",
+    "anciennesCommunes": [
+      {
+        "code": "49160",
+        "nom": "Ingrandes"
+      },
+      {
+        "code": "49321",
+        "nom": "Saint-Sigismond"
+      },
+      {
+        "code": "49382",
+        "nom": "Le Fresne-sur-Loire"
+      }
+    ]
+  },
+  {
+    "code": "49163",
+    "nom": "Jarzé Villages",
+    "anciennesCommunes": [
+      {
+        "code": "49025",
+        "nom": "Beauvau"
+      },
+      {
+        "code": "49084",
+        "nom": "Chaumont-d'Anjou"
+      },
+      {
+        "code": "49163",
+        "nom": "Jarzé"
+      },
+      {
+        "code": "49185",
+        "nom": "Lué-en-Baugeois"
+      }
+    ]
+  },
+  {
+    "code": "49167",
+    "nom": "Les Garennes sur Loire",
+    "anciennesCommunes": [
+      {
+        "code": "49167",
+        "nom": "Juigné-sur-Loire"
+      },
+      {
+        "code": "49290",
+        "nom": "Saint-Jean-des-Mauvrets"
+      }
+    ]
+  },
+  {
+    "code": "49174",
+    "nom": "Huillé-Lézigné",
+    "anciennesCommunes": [
+      {
+        "code": "49159",
+        "nom": "Huillé"
+      },
+      {
+        "code": "49174",
+        "nom": "Lézigné"
+      }
+    ]
+  },
+  {
+    "code": "49176",
+    "nom": "Le Lion-d'Angers",
+    "anciennesCommunes": [
+      {
+        "code": "49005",
+        "nom": "Andigné"
+      },
+      {
+        "code": "49176",
+        "nom": "Le Lion-d'Angers"
+      }
+    ]
+  },
+  {
+    "code": "49183",
+    "nom": "Val d'Erdre-Auxence",
+    "anciennesCommunes": [
+      {
+        "code": "49108",
+        "nom": "La Cornuaille"
+      },
+      {
+        "code": "49183",
+        "nom": "Le Louroux-Béconnais"
+      },
+      {
+        "code": "49376",
+        "nom": "Villemoisan"
+      }
+    ]
+  },
+  {
+    "code": "49194",
+    "nom": "Mazé-Milon",
+    "anciennesCommunes": [
+      {
+        "code": "49139",
+        "nom": "Fontaine-Milon"
+      },
+      {
+        "code": "49194",
+        "nom": "Mazé"
+      }
+    ]
+  },
+  {
+    "code": "49200",
+    "nom": "Longuenée-en-Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49196",
+        "nom": "La Meignanne"
+      },
+      {
+        "code": "49200",
+        "nom": "La Membrolle-sur-Longuenée"
+      },
+      {
+        "code": "49242",
+        "nom": "Le Plessis-Macé"
+      },
+      {
+        "code": "49251",
+        "nom": "Pruillé"
+      }
+    ]
+  },
+  {
+    "code": "49218",
+    "nom": "Montrevault-sur-Èvre",
+    "anciennesCommunes": [
+      {
+        "code": "49033",
+        "nom": "La Boissière-sur-Èvre"
+      },
+      {
+        "code": "49083",
+        "nom": "Chaudron-en-Mauges"
+      },
+      {
+        "code": "49085",
+        "nom": "La Chaussaire"
+      },
+      {
+        "code": "49137",
+        "nom": "Le Fief-Sauvin"
+      },
+      {
+        "code": "49145",
+        "nom": "Le Fuilet"
+      },
+      {
+        "code": "49218",
+        "nom": "Montrevault"
+      },
+      {
+        "code": "49252",
+        "nom": "Le Puiset-Doré"
+      },
+      {
+        "code": "49313",
+        "nom": "Saint-Pierre-Montlimart"
+      },
+      {
+        "code": "49314",
+        "nom": "Saint-Quentin-en-Mauges"
+      },
+      {
+        "code": "49316",
+        "nom": "Saint-Rémy-en-Mauges"
+      },
+      {
+        "code": "49324",
+        "nom": "La Salle-et-Chapelle-Aubry"
+      }
+    ]
+  },
+  {
+    "code": "49220",
+    "nom": "Morannes sur Sarthe-Daumeray",
+    "anciennesCommunes": [
+      {
+        "code": "49093",
+        "nom": "Chemiré-sur-Sarthe"
+      },
+      {
+        "code": "49119",
+        "nom": "Daumeray"
+      },
+      {
+        "code": "49220",
+        "nom": "Morannes"
+      }
+    ]
+  },
+  {
+    "code": "49228",
+    "nom": "Noyant-Villages",
+    "anciennesCommunes": [
+      {
+        "code": "49013",
+        "nom": "Auverse"
+      },
+      {
+        "code": "49044",
+        "nom": "Breil"
+      },
+      {
+        "code": "49052",
+        "nom": "Broc"
+      },
+      {
+        "code": "49062",
+        "nom": "Chalonnes-sous-le-Lude"
+      },
+      {
+        "code": "49087",
+        "nom": "Chavaignes"
+      },
+      {
+        "code": "49098",
+        "nom": "Chigné"
+      },
+      {
+        "code": "49122",
+        "nom": "Dénezé-sous-le-Lude"
+      },
+      {
+        "code": "49150",
+        "nom": "Genneteil"
+      },
+      {
+        "code": "49173",
+        "nom": "Lasse"
+      },
+      {
+        "code": "49175",
+        "nom": "Linières-Bouton"
+      },
+      {
+        "code": "49197",
+        "nom": "Meigné-le-Vicomte"
+      },
+      {
+        "code": "49202",
+        "nom": "Méon"
+      },
+      {
+        "code": "49228",
+        "nom": "Noyant"
+      },
+      {
+        "code": "49234",
+        "nom": "Parçay-les-Pins"
+      }
+    ]
+  },
+  {
+    "code": "49244",
+    "nom": "Mauges-sur-Loire",
+    "anciennesCommunes": [
+      {
+        "code": "49024",
+        "nom": "Beausse"
+      },
+      {
+        "code": "49034",
+        "nom": "Botz-en-Mauges"
+      },
+      {
+        "code": "49039",
+        "nom": "Bourgneuf-en-Mauges"
+      },
+      {
+        "code": "49075",
+        "nom": "La Chapelle-Saint-Florent"
+      },
+      {
+        "code": "49190",
+        "nom": "Le Marillais"
+      },
+      {
+        "code": "49204",
+        "nom": "Le Mesnil-en-Vallée"
+      },
+      {
+        "code": "49212",
+        "nom": "Montjean-sur-Loire"
+      },
+      {
+        "code": "49244",
+        "nom": "La Pommeraye"
+      },
+      {
+        "code": "49276",
+        "nom": "Saint-Florent-le-Vieil"
+      },
+      {
+        "code": "49295",
+        "nom": "Saint-Laurent-de-la-Plaine"
+      },
+      {
+        "code": "49297",
+        "nom": "Saint-Laurent-du-Mottay"
+      }
+    ]
+  },
+  {
+    "code": "49248",
+    "nom": "Ombrée d'Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49073",
+        "nom": "La Chapelle-Hullin"
+      },
+      {
+        "code": "49088",
+        "nom": "Chazé-Henry"
+      },
+      {
+        "code": "49103",
+        "nom": "Combrée"
+      },
+      {
+        "code": "49156",
+        "nom": "Grugé-l'Hôpital"
+      },
+      {
+        "code": "49226",
+        "nom": "Noëllet"
+      },
+      {
+        "code": "49248",
+        "nom": "Pouancé"
+      },
+      {
+        "code": "49250",
+        "nom": "La Prévière"
+      },
+      {
+        "code": "49309",
+        "nom": "Saint-Michel-et-Chanveaux"
+      },
+      {
+        "code": "49354",
+        "nom": "Le Tremblay"
+      },
+      {
+        "code": "49366",
+        "nom": "Vergonnes"
+      }
+    ]
+  },
+  {
+    "code": "49261",
+    "nom": "Gennes-Val-de-Loire",
+    "anciennesCommunes": [
+      {
+        "code": "49149",
+        "nom": "Gennes-Val de Loire"
+      },
+      {
+        "code": "49261",
+        "nom": "Les Rosiers-sur-Loire"
+      },
+      {
+        "code": "49304",
+        "nom": "Saint-Martin-de-la-Place"
+      }
+    ]
+  },
+  {
+    "code": "49292",
+    "nom": "Val-du-Layon",
+    "anciennesCommunes": [
+      {
+        "code": "49265",
+        "nom": "Saint-Aubin-de-Luigné"
+      },
+      {
+        "code": "49292",
+        "nom": "Saint-Lambert-du-Lattay"
+      }
+    ]
+  },
+  {
+    "code": "49298",
+    "nom": "Saint-Léger-de-Linières",
+    "anciennesCommunes": [
+      {
+        "code": "49289",
+        "nom": "Saint-Jean-de-Linières"
+      },
+      {
+        "code": "49298",
+        "nom": "Saint-Léger-des-Bois"
+      }
+    ]
+  },
+  {
+    "code": "49301",
+    "nom": "Sèvremoine",
+    "anciennesCommunes": [
+      {
+        "code": "49179",
+        "nom": "Le Longeron"
+      },
+      {
+        "code": "49206",
+        "nom": "Montfaucon-Montigné"
+      },
+      {
+        "code": "49258",
+        "nom": "La Renaudière"
+      },
+      {
+        "code": "49263",
+        "nom": "Roussay"
+      },
+      {
+        "code": "49264",
+        "nom": "Saint-André-de-la-Marche"
+      },
+      {
+        "code": "49273",
+        "nom": "Saint-Crespin-sur-Moine"
+      },
+      {
+        "code": "49285",
+        "nom": "Saint-Germain-sur-Moine"
+      },
+      {
+        "code": "49301",
+        "nom": "Saint-Macaire-en-Mauges"
+      },
+      {
+        "code": "49349",
+        "nom": "Tillières"
+      },
+      {
+        "code": "49350",
+        "nom": "Torfou"
+      }
+    ]
+  },
+  {
+    "code": "49307",
+    "nom": "Loire-Authion",
+    "anciennesCommunes": [
+      {
+        "code": "49004",
+        "nom": "Andard"
+      },
+      {
+        "code": "49019",
+        "nom": "Bauné"
+      },
+      {
+        "code": "49032",
+        "nom": "La Bohalle"
+      },
+      {
+        "code": "49042",
+        "nom": "Brain-sur-l'Authion"
+      },
+      {
+        "code": "49106",
+        "nom": "Corné"
+      },
+      {
+        "code": "49117",
+        "nom": "La Daguenière"
+      },
+      {
+        "code": "49307",
+        "nom": "Saint-Mathurin-sur-Loire"
+      }
+    ]
+  },
+  {
+    "code": "49323",
+    "nom": "Verrières-en-Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49238",
+        "nom": "Pellouailles-les-Vignes"
+      },
+      {
+        "code": "49323",
+        "nom": "Saint-Sylvain-d'Anjou"
+      }
+    ]
+  },
+  {
+    "code": "49331",
+    "nom": "Segré-en-Anjou Bleu",
+    "anciennesCommunes": [
+      {
+        "code": "49014",
+        "nom": "Aviré"
+      },
+      {
+        "code": "49037",
+        "nom": "Le Bourg-d'Iré"
+      },
+      {
+        "code": "49077",
+        "nom": "La Chapelle-sur-Oudon"
+      },
+      {
+        "code": "49081",
+        "nom": "Châtelais"
+      },
+      {
+        "code": "49136",
+        "nom": "La Ferrière-de-Flée"
+      },
+      {
+        "code": "49158",
+        "nom": "L'Hôtellerie-de-Flée"
+      },
+      {
+        "code": "49184",
+        "nom": "Louvaines"
+      },
+      {
+        "code": "49187",
+        "nom": "Marans"
+      },
+      {
+        "code": "49208",
+        "nom": "Montguillon"
+      },
+      {
+        "code": "49229",
+        "nom": "Noyant-la-Gravoyère"
+      },
+      {
+        "code": "49233",
+        "nom": "Nyoiseau"
+      },
+      {
+        "code": "49277",
+        "nom": "Sainte-Gemmes-d'Andigné"
+      },
+      {
+        "code": "49305",
+        "nom": "Saint-Martin-du-Bois"
+      },
+      {
+        "code": "49319",
+        "nom": "Saint-Sauveur-de-Flée"
+      },
+      {
+        "code": "49331",
+        "nom": "Segré"
+      }
+    ]
+  },
+  {
+    "code": "49345",
+    "nom": "Bellevigne-en-Layon",
+    "anciennesCommunes": [
+      {
+        "code": "49066",
+        "nom": "Champ-sur-Layon"
+      },
+      {
+        "code": "49133",
+        "nom": "Faveraye-Mâchelles"
+      },
+      {
+        "code": "49134",
+        "nom": "Faye-d'Anjou"
+      },
+      {
+        "code": "49256",
+        "nom": "Rablay-sur-Layon"
+      },
+      {
+        "code": "49345",
+        "nom": "Thouarcé"
+      }
+    ]
+  },
+  {
+    "code": "49367",
+    "nom": "Erdre-en-Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49043",
+        "nom": "Brain-sur-Longuenée"
+      },
+      {
+        "code": "49148",
+        "nom": "Gené"
+      },
+      {
+        "code": "49249",
+        "nom": "La Pouëze"
+      },
+      {
+        "code": "49367",
+        "nom": "Vern-d'Anjou"
+      }
+    ]
+  },
+  {
+    "code": "49373",
+    "nom": "Lys-Haut-Layon",
+    "anciennesCommunes": [
+      {
+        "code": "49059",
+        "nom": "Les Cerqueux-sous-Passavant"
+      },
+      {
+        "code": "49142",
+        "nom": "La Fosse-de-Tigné"
+      },
+      {
+        "code": "49232",
+        "nom": "Nueil-sur-Layon"
+      },
+      {
+        "code": "49342",
+        "nom": "Tancoigné"
+      },
+      {
+        "code": "49348",
+        "nom": "Tigné"
+      },
+      {
+        "code": "49356",
+        "nom": "Trémont"
+      },
+      {
+        "code": "49373",
+        "nom": "Vihiers"
+      }
+    ]
+  },
+  {
+    "code": "49377",
+    "nom": "Rives-du-Loir-en-Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "49337",
+        "nom": "Soucelles"
+      },
+      {
+        "code": "49377",
+        "nom": "Villevêque"
+      }
+    ]
+  },
+  {
+    "code": "50025",
+    "nom": "Avranches",
+    "anciennesCommunes": [
+      {
+        "code": "50025",
+        "nom": "Avranches"
+      },
+      {
+        "code": "50516",
+        "nom": "Saint-Martin-des-Champs"
+      }
+    ]
+  },
+  {
+    "code": "50041",
+    "nom": "La Hague",
+    "anciennesCommunes": [
+      {
+        "code": "50001",
+        "nom": "Acqueville"
+      },
+      {
+        "code": "50020",
+        "nom": "Auderville"
+      },
+      {
+        "code": "50041",
+        "nom": "Beaumont-Hague"
+      },
+      {
+        "code": "50057",
+        "nom": "Biville"
+      },
+      {
+        "code": "50073",
+        "nom": "Branville-Hague"
+      },
+      {
+        "code": "50163",
+        "nom": "Digulleville"
+      },
+      {
+        "code": "50171",
+        "nom": "Éculleville"
+      },
+      {
+        "code": "50187",
+        "nom": "Flottemanville-Hague"
+      },
+      {
+        "code": "50220",
+        "nom": "Gréville-Hague"
+      },
+      {
+        "code": "50242",
+        "nom": "Herqueville"
+      },
+      {
+        "code": "50257",
+        "nom": "Jobourg"
+      },
+      {
+        "code": "50385",
+        "nom": "Omonville-la-Petite"
+      },
+      {
+        "code": "50386",
+        "nom": "Omonville-la-Rogue"
+      },
+      {
+        "code": "50460",
+        "nom": "Sainte-Croix-Hague"
+      },
+      {
+        "code": "50477",
+        "nom": "Saint-Germain-des-Vaux"
+      },
+      {
+        "code": "50600",
+        "nom": "Tonneville"
+      },
+      {
+        "code": "50611",
+        "nom": "Urville-Nacqueville"
+      },
+      {
+        "code": "50620",
+        "nom": "Vasteville"
+      },
+      {
+        "code": "50623",
+        "nom": "Vauville"
+      }
+    ]
+  },
+  {
+    "code": "50082",
+    "nom": "Bricquebec-en-Cotentin",
+    "anciennesCommunes": [
+      {
+        "code": "50082",
+        "nom": "Bricquebec"
+      },
+      {
+        "code": "50396",
+        "nom": "Les Perques"
+      },
+      {
+        "code": "50418",
+        "nom": "Quettetot"
+      },
+      {
+        "code": "50520",
+        "nom": "Saint-Martin-le-Hébert"
+      },
+      {
+        "code": "50614",
+        "nom": "Le Valdécie"
+      },
+      {
+        "code": "50646",
+        "nom": "Le Vrétot"
+      }
+    ]
+  },
+  {
+    "code": "50090",
+    "nom": "Buais-Les-Monts",
+    "anciennesCommunes": [
+      {
+        "code": "50090",
+        "nom": "Buais"
+      },
+      {
+        "code": "50557",
+        "nom": "Saint-Symphorien-des-Monts"
+      }
+    ]
+  },
+  {
+    "code": "50095",
+    "nom": "Canisy",
+    "anciennesCommunes": [
+      {
+        "code": "50095",
+        "nom": "Canisy"
+      },
+      {
+        "code": "50465",
+        "nom": "Saint-Ébremond-de-Bonfossé"
+      }
+    ]
+  },
+  {
+    "code": "50099",
+    "nom": "Carentan-les-Marais",
+    "anciennesCommunes": [
+      {
+        "code": "50010",
+        "nom": "Angoville-au-Plain"
+      },
+      {
+        "code": "50080",
+        "nom": "Brévands"
+      },
+      {
+        "code": "50089",
+        "nom": "Brucheville"
+      },
+      {
+        "code": "50099",
+        "nom": "Carentan"
+      },
+      {
+        "code": "50107",
+        "nom": "Catz"
+      },
+      {
+        "code": "50249",
+        "nom": "Houesville"
+      },
+      {
+        "code": "50348",
+        "nom": "Montmartin-en-Graignes"
+      },
+      {
+        "code": "50458",
+        "nom": "Saint-Côme-du-Mont"
+      },
+      {
+        "code": "50485",
+        "nom": "Saint-Hilaire-Petitville"
+      },
+      {
+        "code": "50534",
+        "nom": "Saint-Pellerin"
+      },
+      {
+        "code": "50631",
+        "nom": "Les Veys"
+      },
+      {
+        "code": "50636",
+        "nom": "Vierville"
+      }
+    ]
+  },
+  {
+    "code": "50115",
+    "nom": "Le Grippon",
+    "anciennesCommunes": [
+      {
+        "code": "50114",
+        "nom": "Les Chambres"
+      },
+      {
+        "code": "50115",
+        "nom": "Champcervon"
+      }
+    ]
+  },
+  {
+    "code": "50129",
+    "nom": "Cherbourg-en-Cotentin",
+    "anciennesCommunes": [
+      {
+        "code": "50129",
+        "nom": "Cherbourg-Octeville"
+      },
+      {
+        "code": "50173",
+        "nom": "Équeurdreville-Hainneville"
+      },
+      {
+        "code": "50203",
+        "nom": "La Glacerie"
+      },
+      {
+        "code": "50416",
+        "nom": "Querqueville"
+      },
+      {
+        "code": "50602",
+        "nom": "Tourlaville"
+      }
+    ]
+  },
+  {
+    "code": "50139",
+    "nom": "Condé-sur-Vire",
+    "anciennesCommunes": [
+      {
+        "code": "50139",
+        "nom": "Condé-sur-Vire"
+      },
+      {
+        "code": "50319",
+        "nom": "Le Mesnil-Raoult"
+      },
+      {
+        "code": "50608",
+        "nom": "Troisgots"
+      }
+    ]
+  },
+  {
+    "code": "50142",
+    "nom": "Vicq-sur-Mer",
+    "anciennesCommunes": [
+      {
+        "code": "50142",
+        "nom": "Cosqueville"
+      },
+      {
+        "code": "50211",
+        "nom": "Gouberville"
+      },
+      {
+        "code": "50375",
+        "nom": "Néville-sur-Mer"
+      },
+      {
+        "code": "50432",
+        "nom": "Réthoville"
+      }
+    ]
+  },
+  {
+    "code": "50168",
+    "nom": "Ducey-Les Chéris",
+    "anciennesCommunes": [
+      {
+        "code": "50132",
+        "nom": "Les Chéris"
+      },
+      {
+        "code": "50168",
+        "nom": "Ducey"
+      }
+    ]
+  },
+  {
+    "code": "50197",
+    "nom": "Gavray-sur-Sienne",
+    "anciennesCommunes": [
+      {
+        "code": "50197",
+        "nom": "Gavray"
+      },
+      {
+        "code": "50301",
+        "nom": "Le Mesnil-Amand"
+      },
+      {
+        "code": "50320",
+        "nom": "Le Mesnil-Rogues"
+      },
+      {
+        "code": "50583",
+        "nom": "Sourdeval-les-Bois"
+      }
+    ]
+  },
+  {
+    "code": "50209",
+    "nom": "Gonneville-Le Theil",
+    "anciennesCommunes": [
+      {
+        "code": "50209",
+        "nom": "Gonneville"
+      },
+      {
+        "code": "50595",
+        "nom": "Le Theil"
+      }
+    ]
+  },
+  {
+    "code": "50215",
+    "nom": "Gouville-sur-Mer",
+    "anciennesCommunes": [
+      {
+        "code": "50014",
+        "nom": "Anneville-sur-Mer"
+      },
+      {
+        "code": "50061",
+        "nom": "Boisroger"
+      },
+      {
+        "code": "50215",
+        "nom": "Gouville-sur-Mer"
+      },
+      {
+        "code": "50354",
+        "nom": "Montsurvent"
+      },
+      {
+        "code": "50573",
+        "nom": "Servigny"
+      }
+    ]
+  },
+  {
+    "code": "50236",
+    "nom": "La Haye",
+    "anciennesCommunes": [
+      {
+        "code": "50035",
+        "nom": "Baudreville"
+      },
+      {
+        "code": "50063",
+        "nom": "Bolleville"
+      },
+      {
+        "code": "50204",
+        "nom": "Glatigny"
+      },
+      {
+        "code": "50236",
+        "nom": "La Haye-du-Puits"
+      },
+      {
+        "code": "50330",
+        "nom": "Mobecq"
+      },
+      {
+        "code": "50343",
+        "nom": "Montgardon"
+      },
+      {
+        "code": "50544",
+        "nom": "Saint-Rémy-des-Landes"
+      },
+      {
+        "code": "50558",
+        "nom": "Saint-Symphorien-le-Valois"
+      },
+      {
+        "code": "50586",
+        "nom": "Surville"
+      }
+    ]
+  },
+  {
+    "code": "50239",
+    "nom": "Thèreval",
+    "anciennesCommunes": [
+      {
+        "code": "50123",
+        "nom": "La Chapelle-en-Juger"
+      },
+      {
+        "code": "50239",
+        "nom": "Hébécrevon"
+      }
+    ]
+  },
+  {
+    "code": "50260",
+    "nom": "Juvigny les Vallées",
+    "anciennesCommunes": [
+      {
+        "code": "50037",
+        "nom": "La Bazoge"
+      },
+      {
+        "code": "50043",
+        "nom": "Bellefontaine"
+      },
+      {
+        "code": "50125",
+        "nom": "Chasseguey"
+      },
+      {
+        "code": "50131",
+        "nom": "Chérencé-le-Roussel"
+      },
+      {
+        "code": "50260",
+        "nom": "Juvigny-le-Tertre"
+      },
+      {
+        "code": "50318",
+        "nom": "Le Mesnil-Rainfray"
+      },
+      {
+        "code": "50323",
+        "nom": "Le Mesnil-Tôve"
+      }
+    ]
+  },
+  {
+    "code": "50267",
+    "nom": "Lessay",
+    "anciennesCommunes": [
+      {
+        "code": "50012",
+        "nom": "Angoville-sur-Ay"
+      },
+      {
+        "code": "50267",
+        "nom": "Lessay"
+      }
+    ]
+  },
+  {
+    "code": "50272",
+    "nom": "Tourneville-sur-Mer",
+    "anciennesCommunes": [
+      {
+        "code": "50015",
+        "nom": "Annoville"
+      },
+      {
+        "code": "50272",
+        "nom": "Lingreville"
+      }
+    ]
+  },
+  {
+    "code": "50273",
+    "nom": "Montsenelle",
+    "anciennesCommunes": [
+      {
+        "code": "50136",
+        "nom": "Coigny"
+      },
+      {
+        "code": "50273",
+        "nom": "Lithaire"
+      },
+      {
+        "code": "50415",
+        "nom": "Prétot-Sainte-Suzanne"
+      },
+      {
+        "code": "50497",
+        "nom": "Saint-Jores"
+      }
+    ]
+  },
+  {
+    "code": "50292",
+    "nom": "Marigny-Le-Lozon",
+    "anciennesCommunes": [
+      {
+        "code": "50280",
+        "nom": "Lozon"
+      },
+      {
+        "code": "50292",
+        "nom": "Marigny"
+      }
+    ]
+  },
+  {
+    "code": "50359",
+    "nom": "Mortain-Bocage",
+    "anciennesCommunes": [
+      {
+        "code": "50056",
+        "nom": "Bion"
+      },
+      {
+        "code": "50359",
+        "nom": "Mortain"
+      },
+      {
+        "code": "50381",
+        "nom": "Notre-Dame-du-Touchet"
+      },
+      {
+        "code": "50494",
+        "nom": "Saint-Jean-du-Corail"
+      },
+      {
+        "code": "50638",
+        "nom": "Villechien"
+      }
+    ]
+  },
+  {
+    "code": "50363",
+    "nom": "Moyon Villages",
+    "anciennesCommunes": [
+      {
+        "code": "50134",
+        "nom": "Chevry"
+      },
+      {
+        "code": "50313",
+        "nom": "Le Mesnil-Herman"
+      },
+      {
+        "code": "50316",
+        "nom": "Le Mesnil-Opac"
+      },
+      {
+        "code": "50363",
+        "nom": "Moyon"
+      }
+    ]
+  },
+  {
+    "code": "50388",
+    "nom": "Orval sur Sienne",
+    "anciennesCommunes": [
+      {
+        "code": "50339",
+        "nom": "Montchaton"
+      },
+      {
+        "code": "50388",
+        "nom": "Orval"
+      }
+    ]
+  },
+  {
+    "code": "50391",
+    "nom": "Grandparigny",
+    "anciennesCommunes": [
+      {
+        "code": "50133",
+        "nom": "Chèvreville"
+      },
+      {
+        "code": "50293",
+        "nom": "Martigny"
+      },
+      {
+        "code": "50329",
+        "nom": "Milly"
+      },
+      {
+        "code": "50391",
+        "nom": "Parigny"
+      }
+    ]
+  },
+  {
+    "code": "50393",
+    "nom": "Percy-en-Normandie",
+    "anciennesCommunes": [
+      {
+        "code": "50128",
+        "nom": "Le Chefresne"
+      },
+      {
+        "code": "50393",
+        "nom": "Percy"
+      }
+    ]
+  },
+  {
+    "code": "50400",
+    "nom": "Picauville",
+    "anciennesCommunes": [
+      {
+        "code": "50005",
+        "nom": "Amfreville"
+      },
+      {
+        "code": "50153",
+        "nom": "Cretteville"
+      },
+      {
+        "code": "50212",
+        "nom": "Gourbesville"
+      },
+      {
+        "code": "50250",
+        "nom": "Houtteville"
+      },
+      {
+        "code": "50333",
+        "nom": "Les Moitiers-en-Bauptois"
+      },
+      {
+        "code": "50400",
+        "nom": "Picauville"
+      },
+      {
+        "code": "50642",
+        "nom": "Vindefontaine"
+      }
+    ]
+  },
+  {
+    "code": "50409",
+    "nom": "Pont-Hébert",
+    "anciennesCommunes": [
+      {
+        "code": "50248",
+        "nom": "Le Hommet-d'Arthenay"
+      },
+      {
+        "code": "50409",
+        "nom": "Pont-Hébert"
+      }
+    ]
+  },
+  {
+    "code": "50410",
+    "nom": "Pontorson",
+    "anciennesCommunes": [
+      {
+        "code": "50284",
+        "nom": "Macey"
+      },
+      {
+        "code": "50410",
+        "nom": "Pontorson"
+      },
+      {
+        "code": "50630",
+        "nom": "Vessey"
+      }
+    ]
+  },
+  {
+    "code": "50412",
+    "nom": "Port-Bail-sur-Mer",
+    "anciennesCommunes": [
+      {
+        "code": "50160",
+        "nom": "Denneville"
+      },
+      {
+        "code": "50412",
+        "nom": "Portbail"
+      },
+      {
+        "code": "50503",
+        "nom": "Saint-Lô-d'Ourville"
+      }
+    ]
+  },
+  {
+    "code": "50417",
+    "nom": "Quettehou",
+    "anciennesCommunes": [
+      {
+        "code": "50358",
+        "nom": "Morsalines"
+      },
+      {
+        "code": "50417",
+        "nom": "Quettehou"
+      }
+    ]
+  },
+  {
+    "code": "50419",
+    "nom": "Quettreville-sur-Sienne",
+    "anciennesCommunes": [
+      {
+        "code": "50140",
+        "nom": "Contrières"
+      },
+      {
+        "code": "50223",
+        "nom": "Guéhébert"
+      },
+      {
+        "code": "50244",
+        "nom": "Hérenguerville"
+      },
+      {
+        "code": "50255",
+        "nom": "Hyenville"
+      },
+      {
+        "code": "50419",
+        "nom": "Quettreville-sur-Sienne"
+      },
+      {
+        "code": "50605",
+        "nom": "Trelly"
+      }
+    ]
+  },
+  {
+    "code": "50431",
+    "nom": "Remilly Les Marais",
+    "anciennesCommunes": [
+      {
+        "code": "50119",
+        "nom": "Les Champs-de-Losque"
+      },
+      {
+        "code": "50325",
+        "nom": "Le Mesnil-Vigot"
+      },
+      {
+        "code": "50431",
+        "nom": "Remilly-sur-Lozon"
+      }
+    ]
+  },
+  {
+    "code": "50436",
+    "nom": "Romagny Fontenay",
+    "anciennesCommunes": [
+      {
+        "code": "50189",
+        "nom": "Fontenay"
+      },
+      {
+        "code": "50436",
+        "nom": "Romagny"
+      }
+    ]
+  },
+  {
+    "code": "50444",
+    "nom": "Saint-Amand-Villages",
+    "anciennesCommunes": [
+      {
+        "code": "50404",
+        "nom": "Placy-Montaigu"
+      },
+      {
+        "code": "50444",
+        "nom": "Saint-Amand"
+      }
+    ]
+  },
+  {
+    "code": "50484",
+    "nom": "Saint-Hilaire-du-Harcouët",
+    "anciennesCommunes": [
+      {
+        "code": "50484",
+        "nom": "Saint-Hilaire-du-Harcouët"
+      },
+      {
+        "code": "50515",
+        "nom": "Saint-Martin-de-Landelles"
+      },
+      {
+        "code": "50644",
+        "nom": "Virey"
+      }
+    ]
+  },
+  {
+    "code": "50487",
+    "nom": "Saint-James",
+    "anciennesCommunes": [
+      {
+        "code": "50018",
+        "nom": "Argouges"
+      },
+      {
+        "code": "50100",
+        "nom": "Carnet"
+      },
+      {
+        "code": "50154",
+        "nom": "La Croix-Avranchin"
+      },
+      {
+        "code": "50337",
+        "nom": "Montanel"
+      },
+      {
+        "code": "50487",
+        "nom": "Saint-James"
+      },
+      {
+        "code": "50627",
+        "nom": "Vergoncey"
+      },
+      {
+        "code": "50640",
+        "nom": "Villiers-le-Pré"
+      }
+    ]
+  },
+  {
+    "code": "50492",
+    "nom": "Saint-Jean-d'Elle",
+    "anciennesCommunes": [
+      {
+        "code": "50380",
+        "nom": "Notre-Dame-d'Elle"
+      },
+      {
+        "code": "50414",
+        "nom": "Précorbin"
+      },
+      {
+        "code": "50441",
+        "nom": "Rouxeville"
+      },
+      {
+        "code": "50492",
+        "nom": "Saint-Jean-des-Baisants"
+      },
+      {
+        "code": "50635",
+        "nom": "Vidouville"
+      }
+    ]
+  },
+  {
     "code": "50523",
     "nom": "Sainte-Mère-Église",
     "anciennesCommunes": [
@@ -30,6 +10228,5936 @@
       {
         "code": "50523",
         "nom": "Sainte-Mère-Église"
+      }
+    ]
+  },
+  {
+    "code": "50535",
+    "nom": "Le Parc",
+    "anciennesCommunes": [
+      {
+        "code": "50071",
+        "nom": "Braffais"
+      },
+      {
+        "code": "50406",
+        "nom": "Plomb"
+      },
+      {
+        "code": "50535",
+        "nom": "Sainte-Pience"
+      }
+    ]
+  },
+  {
+    "code": "50546",
+    "nom": "Bourgvallées",
+    "anciennesCommunes": [
+      {
+        "code": "50213",
+        "nom": "Gourfaleur"
+      },
+      {
+        "code": "50287",
+        "nom": "La Mancellière-sur-Vire"
+      },
+      {
+        "code": "50313",
+        "nom": "Le Mesnil-Herman"
+      },
+      {
+        "code": "50545",
+        "nom": "Saint-Romphaire"
+      },
+      {
+        "code": "50546",
+        "nom": "Saint-Samson-de-Bonfossé"
+      },
+      {
+        "code": "50581",
+        "nom": "Soulles"
+      }
+    ]
+  },
+  {
+    "code": "50550",
+    "nom": "Saint-Sauveur-Villages",
+    "anciennesCommunes": [
+      {
+        "code": "50007",
+        "nom": "Ancteville"
+      },
+      {
+        "code": "50308",
+        "nom": "Le Mesnilbus"
+      },
+      {
+        "code": "50438",
+        "nom": "La Ronde-Haye"
+      },
+      {
+        "code": "50449",
+        "nom": "Saint-Aubin-du-Perron"
+      },
+      {
+        "code": "50524",
+        "nom": "Saint-Michel-de-la-Pierre"
+      },
+      {
+        "code": "50550",
+        "nom": "Saint-Sauveur-Lendelin"
+      },
+      {
+        "code": "50622",
+        "nom": "Vaudrimesnil"
+      }
+    ]
+  },
+  {
+    "code": "50564",
+    "nom": "Terre-et-Marais",
+    "anciennesCommunes": [
+      {
+        "code": "50470",
+        "nom": "Saint-Georges-de-Bohon"
+      },
+      {
+        "code": "50564",
+        "nom": "Sainteny"
+      }
+    ]
+  },
+  {
+    "code": "50565",
+    "nom": "Sartilly-Baie-Bocage",
+    "anciennesCommunes": [
+      {
+        "code": "50009",
+        "nom": "Angey"
+      },
+      {
+        "code": "50116",
+        "nom": "Champcey"
+      },
+      {
+        "code": "50355",
+        "nom": "Montviron"
+      },
+      {
+        "code": "50434",
+        "nom": "La Rochelle-Normande"
+      },
+      {
+        "code": "50565",
+        "nom": "Sartilly"
+      }
+    ]
+  },
+  {
+    "code": "50582",
+    "nom": "Sourdeval",
+    "anciennesCommunes": [
+      {
+        "code": "50582",
+        "nom": "Sourdeval"
+      },
+      {
+        "code": "50625",
+        "nom": "Vengeons"
+      }
+    ]
+  },
+  {
+    "code": "50591",
+    "nom": "Le Teilleul",
+    "anciennesCommunes": [
+      {
+        "code": "50179",
+        "nom": "Ferrières"
+      },
+      {
+        "code": "50245",
+        "nom": "Heussé"
+      },
+      {
+        "code": "50254",
+        "nom": "Husson"
+      },
+      {
+        "code": "50508",
+        "nom": "Sainte-Marie-du-Bois"
+      },
+      {
+        "code": "50591",
+        "nom": "Le Teilleul"
+      }
+    ]
+  },
+  {
+    "code": "50592",
+    "nom": "Tessy-Bocage",
+    "anciennesCommunes": [
+      {
+        "code": "50180",
+        "nom": "Fervaches"
+      },
+      {
+        "code": "50592",
+        "nom": "Tessy-sur-Vire"
+      },
+      {
+        "code": "50649",
+        "nom": "Pont-Farcy"
+      }
+    ]
+  },
+  {
+    "code": "50597",
+    "nom": "Tirepied-sur-Sée",
+    "anciennesCommunes": [
+      {
+        "code": "50206",
+        "nom": "La Gohannière"
+      },
+      {
+        "code": "50597",
+        "nom": "Tirepied"
+      }
+    ]
+  },
+  {
+    "code": "50601",
+    "nom": "Torigny-les-Villes",
+    "anciennesCommunes": [
+      {
+        "code": "50075",
+        "nom": "Brectouville"
+      },
+      {
+        "code": "50202",
+        "nom": "Giéville"
+      },
+      {
+        "code": "50224",
+        "nom": "Guilberville"
+      },
+      {
+        "code": "50601",
+        "nom": "Torigni-sur-Vire"
+      }
+    ]
+  },
+  {
+    "code": "50639",
+    "nom": "Villedieu-les-Poêles-Rouffigny",
+    "anciennesCommunes": [
+      {
+        "code": "50440",
+        "nom": "Rouffigny"
+      },
+      {
+        "code": "50639",
+        "nom": "Villedieu-les-Poêles"
+      }
+    ]
+  },
+  {
+    "code": "51030",
+    "nom": "Aÿ-Champagne",
+    "anciennesCommunes": [
+      {
+        "code": "51030",
+        "nom": "Ay"
+      },
+      {
+        "code": "51064",
+        "nom": "Bisseuil"
+      },
+      {
+        "code": "51347",
+        "nom": "Mareuil-sur-Ay"
+      }
+    ]
+  },
+  {
+    "code": "51075",
+    "nom": "Bourgogne-Fresne",
+    "anciennesCommunes": [
+      {
+        "code": "51075",
+        "nom": "Bourgogne"
+      },
+      {
+        "code": "51261",
+        "nom": "Fresne-lès-Reims"
+      }
+    ]
+  },
+  {
+    "code": "51171",
+    "nom": "Cormicy",
+    "anciennesCommunes": [
+      {
+        "code": "51171",
+        "nom": "Cormicy"
+      },
+      {
+        "code": "51664",
+        "nom": "Gernicourt"
+      }
+    ]
+  },
+  {
+    "code": "51457",
+    "nom": "Cœur-de-la-Vallée",
+    "anciennesCommunes": [
+      {
+        "code": "51063",
+        "nom": "Binson-et-Orquigny"
+      },
+      {
+        "code": "51457",
+        "nom": "Reuil"
+      },
+      {
+        "code": "51637",
+        "nom": "Villers-sous-Châtillon"
+      }
+    ]
+  },
+  {
+    "code": "51485",
+    "nom": "La Neuville-au-Temple",
+    "anciennesCommunes": [
+      {
+        "code": "51205",
+        "nom": "Dampierre-au-Temple"
+      },
+      {
+        "code": "51485",
+        "nom": "Saint-Hilaire-au-Temple"
+      }
+    ]
+  },
+  {
+    "code": "51564",
+    "nom": "Val de Livre",
+    "anciennesCommunes": [
+      {
+        "code": "51331",
+        "nom": "Louvois"
+      },
+      {
+        "code": "51564",
+        "nom": "Tauxières-Mutry"
+      }
+    ]
+  },
+  {
+    "code": "51612",
+    "nom": "Blancs-Coteaux",
+    "anciennesCommunes": [
+      {
+        "code": "51271",
+        "nom": "Gionges"
+      },
+      {
+        "code": "51411",
+        "nom": "Oger"
+      },
+      {
+        "code": "51612",
+        "nom": "Vertus"
+      },
+      {
+        "code": "51651",
+        "nom": "Voipreux"
+      }
+    ]
+  },
+  {
+    "code": "52031",
+    "nom": "Autreville-sur-la-Renne",
+    "anciennesCommunes": [
+      {
+        "code": "52031",
+        "nom": "Autreville-sur-la-Renne"
+      }
+    ]
+  },
+  {
+    "code": "52064",
+    "nom": "Bourmont-entre-Meuse-et-Mouzon",
+    "anciennesCommunes": [
+      {
+        "code": "52064",
+        "nom": "Bourmont"
+      },
+      {
+        "code": "52225",
+        "nom": "Goncourt"
+      },
+      {
+        "code": "52351",
+        "nom": "Nijon"
+      }
+    ]
+  },
+  {
+    "code": "52125",
+    "nom": "Chamarandes-Choignes",
+    "anciennesCommunes": [
+      {
+        "code": "52125",
+        "nom": "Chamarandes-Choignes"
+      }
+    ]
+  },
+  {
+    "code": "52140",
+    "nom": "Colombey les Deux Églises",
+    "anciennesCommunes": [
+      {
+        "code": "52140",
+        "nom": "Colombey-les-Deux-Églises"
+      },
+      {
+        "code": "52262",
+        "nom": "Lamothe-en-Blaisy"
+      }
+    ]
+  },
+  {
+    "code": "52187",
+    "nom": "Épizon",
+    "anciennesCommunes": [
+      {
+        "code": "52187",
+        "nom": "Épizon"
+      },
+      {
+        "code": "52379",
+        "nom": "Pautaines-Augeville"
+      }
+    ]
+  },
+  {
+    "code": "52331",
+    "nom": "La Porte du Der",
+    "anciennesCommunes": [
+      {
+        "code": "52331",
+        "nom": "Montier-en-Der"
+      },
+      {
+        "code": "52427",
+        "nom": "Robert-Magny"
+      }
+    ]
+  },
+  {
+    "code": "52332",
+    "nom": "Val-de-Meuse",
+    "anciennesCommunes": [
+      {
+        "code": "52332",
+        "nom": "Val-de-Meuse"
+      }
+    ]
+  },
+  {
+    "code": "52405",
+    "nom": "Le Montsaugeonnais",
+    "anciennesCommunes": [
+      {
+        "code": "52340",
+        "nom": "Montsaugeon"
+      },
+      {
+        "code": "52405",
+        "nom": "Prauthoy"
+      },
+      {
+        "code": "52509",
+        "nom": "Vaux-sous-Aubigny"
+      }
+    ]
+  },
+  {
+    "code": "52411",
+    "nom": "Rives Dervoises",
+    "anciennesCommunes": [
+      {
+        "code": "52180",
+        "nom": "Droyes"
+      },
+      {
+        "code": "52293",
+        "nom": "Longeville-sur-la-Laines"
+      },
+      {
+        "code": "52296",
+        "nom": "Louze"
+      },
+      {
+        "code": "52411",
+        "nom": "Puellemontier"
+      }
+    ]
+  },
+  {
+    "code": "52449",
+    "nom": "Saints-Geosmes",
+    "anciennesCommunes": [
+      {
+        "code": "52036",
+        "nom": "Balesmes-sur-Marne"
+      },
+      {
+        "code": "52449",
+        "nom": "Saints-Geosmes"
+      }
+    ]
+  },
+  {
+    "code": "52529",
+    "nom": "Villegusien-le-Lac",
+    "anciennesCommunes": [
+      {
+        "code": "52239",
+        "nom": "Heuilley-Cotton"
+      },
+      {
+        "code": "52529",
+        "nom": "Villegusien-le-Lac"
+      }
+    ]
+  },
+  {
+    "code": "53003",
+    "nom": "Ambrières-les-Vallées",
+    "anciennesCommunes": [
+      {
+        "code": "53003",
+        "nom": "Ambrières-les-Vallées"
+      }
+    ]
+  },
+  {
+    "code": "53017",
+    "nom": "Val-du-Maine",
+    "anciennesCommunes": [
+      {
+        "code": "53017",
+        "nom": "Ballée"
+      },
+      {
+        "code": "53095",
+        "nom": "Épineux-le-Seguin"
+      }
+    ]
+  },
+  {
+    "code": "53029",
+    "nom": "Bierné-les-Villages",
+    "anciennesCommunes": [
+      {
+        "code": "53006",
+        "nom": "Argenton-Notre-Dame"
+      },
+      {
+        "code": "53029",
+        "nom": "Bierné"
+      },
+      {
+        "code": "53231",
+        "nom": "Saint-Laurent-des-Mortiers"
+      },
+      {
+        "code": "53241",
+        "nom": "Saint-Michel-de-Feins"
+      }
+    ]
+  },
+  {
+    "code": "53062",
+    "nom": "Château-Gontier-sur-Mayenne",
+    "anciennesCommunes": [
+      {
+        "code": "53014",
+        "nom": "Azé"
+      },
+      {
+        "code": "53062",
+        "nom": "Château-Gontier"
+      },
+      {
+        "code": "53215",
+        "nom": "Saint-Fort"
+      }
+    ]
+  },
+  {
+    "code": "53079",
+    "nom": "Couesmes-Vaucé",
+    "anciennesCommunes": [
+      {
+        "code": "53079",
+        "nom": "Couesmes-Vaucé"
+      }
+    ]
+  },
+  {
+    "code": "53097",
+    "nom": "Évron",
+    "anciennesCommunes": [
+      {
+        "code": "53065",
+        "nom": "Châtres-la-Forêt"
+      },
+      {
+        "code": "53097",
+        "nom": "Évron"
+      },
+      {
+        "code": "53207",
+        "nom": "Saint-Christophe-du-Luat"
+      }
+    ]
+  },
+  {
+    "code": "53104",
+    "nom": "Gennes-Longuefuye",
+    "anciennesCommunes": [
+      {
+        "code": "53104",
+        "nom": "Gennes-sur-Glaize"
+      },
+      {
+        "code": "53138",
+        "nom": "Longuefuye"
+      }
+    ]
+  },
+  {
+    "code": "53124",
+    "nom": "Prée-d'Anjou",
+    "anciennesCommunes": [
+      {
+        "code": "53004",
+        "nom": "Ampoigné"
+      },
+      {
+        "code": "53124",
+        "nom": "Laigné"
+      }
+    ]
+  },
+  {
+    "code": "53127",
+    "nom": "Lassay-les-Châteaux",
+    "anciennesCommunes": [
+      {
+        "code": "53127",
+        "nom": "Lassay-les-Châteaux"
+      }
+    ]
+  },
+  {
+    "code": "53136",
+    "nom": "La Roche-Neuville",
+    "anciennesCommunes": [
+      {
+        "code": "53136",
+        "nom": "Loigné-sur-Mayenne"
+      },
+      {
+        "code": "53254",
+        "nom": "Saint-Sulpice"
+      }
+    ]
+  },
+  {
+    "code": "53137",
+    "nom": "Loiron-Ruillé",
+    "anciennesCommunes": [
+      {
+        "code": "53137",
+        "nom": "Loiron"
+      },
+      {
+        "code": "53194",
+        "nom": "Ruillé-le-Gravelais"
+      }
+    ]
+  },
+  {
+    "code": "53161",
+    "nom": "Montsûrs",
+    "anciennesCommunes": [
+      {
+        "code": "53092",
+        "nom": "Deux-Évailles"
+      },
+      {
+        "code": "53159",
+        "nom": "Montourtier"
+      },
+      {
+        "code": "53161",
+        "nom": "Montsûrs"
+      },
+      {
+        "code": "53205",
+        "nom": "Saint-Céneré"
+      },
+      {
+        "code": "53244",
+        "nom": "Saint-Ouën-des-Vallons"
+      }
+    ]
+  },
+  {
+    "code": "53185",
+    "nom": "Pré-en-Pail-Saint-Samson",
+    "anciennesCommunes": [
+      {
+        "code": "53185",
+        "nom": "Pré-en-Pail"
+      },
+      {
+        "code": "53252",
+        "nom": "Saint-Samson"
+      }
+    ]
+  },
+  {
+    "code": "53228",
+    "nom": "Blandouet-Saint Jean",
+    "anciennesCommunes": [
+      {
+        "code": "53032",
+        "nom": "Blandouet"
+      },
+      {
+        "code": "53228",
+        "nom": "Saint-Jean-sur-Erve"
+      }
+    ]
+  },
+  {
+    "code": "53249",
+    "nom": "Vimartin-sur-Orthe",
+    "anciennesCommunes": [
+      {
+        "code": "53239",
+        "nom": "Saint-Martin-de-Connée"
+      },
+      {
+        "code": "53249",
+        "nom": "Saint-Pierre-sur-Orthe"
+      },
+      {
+        "code": "53274",
+        "nom": "Vimarcé"
+      }
+    ]
+  },
+  {
+    "code": "53255",
+    "nom": "Sainte-Suzanne-et-Chammes",
+    "anciennesCommunes": [
+      {
+        "code": "53050",
+        "nom": "Chammes"
+      },
+      {
+        "code": "53255",
+        "nom": "Sainte-Suzanne"
+      }
+    ]
+  },
+  {
+    "code": "54099",
+    "nom": "Val de Briey",
+    "anciennesCommunes": [
+      {
+        "code": "54099",
+        "nom": "Briey"
+      },
+      {
+        "code": "54341",
+        "nom": "Mance"
+      },
+      {
+        "code": "54342",
+        "nom": "Mancieulles"
+      }
+    ]
+  },
+  {
+    "code": "54557",
+    "nom": "Bois-de-Haye",
+    "anciennesCommunes": [
+      {
+        "code": "54506",
+        "nom": "Sexey-les-Bois"
+      },
+      {
+        "code": "54557",
+        "nom": "Velaine-en-Haye"
+      }
+    ]
+  },
+  {
+    "code": "55060",
+    "nom": "Bonzée",
+    "anciennesCommunes": [
+      {
+        "code": "55060",
+        "nom": "Bonzée"
+      }
+    ]
+  },
+  {
+    "code": "55094",
+    "nom": "Buzy-Darmont",
+    "anciennesCommunes": [
+      {
+        "code": "55094",
+        "nom": "Buzy-Darmont"
+      }
+    ]
+  },
+  {
+    "code": "55150",
+    "nom": "Demange-Baudignécourt",
+    "anciennesCommunes": [
+      {
+        "code": "55030",
+        "nom": "Baudignécourt"
+      },
+      {
+        "code": "55150",
+        "nom": "Demange-aux-Eaux"
+      }
+    ]
+  },
+  {
+    "code": "55457",
+    "nom": "Saint-Hilaire-en-Woëvre",
+    "anciennesCommunes": [
+      {
+        "code": "55457",
+        "nom": "Saint-Hilaire-en-Woëvre"
+      }
+    ]
+  },
+  {
+    "code": "55537",
+    "nom": "Douaumont-Vaux",
+    "anciennesCommunes": [
+      {
+        "code": "55164",
+        "nom": "Douaumont"
+      },
+      {
+        "code": "55537",
+        "nom": "Vaux-devant-Damloup"
+      }
+    ]
+  },
+  {
+    "code": "56033",
+    "nom": "Carentoir",
+    "anciennesCommunes": [
+      {
+        "code": "56033",
+        "nom": "Carentoir"
+      },
+      {
+        "code": "56183",
+        "nom": "Quelneuc"
+      }
+    ]
+  },
+  {
+    "code": "56061",
+    "nom": "La Gacilly",
+    "anciennesCommunes": [
+      {
+        "code": "56038",
+        "nom": "La Chapelle-Gaceline"
+      },
+      {
+        "code": "56061",
+        "nom": "La Gacilly"
+      },
+      {
+        "code": "56064",
+        "nom": "Glénac"
+      }
+    ]
+  },
+  {
+    "code": "56102",
+    "nom": "Forges de Lanouée",
+    "anciennesCommunes": [
+      {
+        "code": "56059",
+        "nom": "Les Forges"
+      },
+      {
+        "code": "56102",
+        "nom": "Lanouée"
+      }
+    ]
+  },
+  {
+    "code": "56144",
+    "nom": "Évellys",
+    "anciennesCommunes": [
+      {
+        "code": "56142",
+        "nom": "Moustoir-Remungol"
+      },
+      {
+        "code": "56144",
+        "nom": "Naizin"
+      },
+      {
+        "code": "56192",
+        "nom": "Remungol"
+      }
+    ]
+  },
+  {
+    "code": "56165",
+    "nom": "Ploërmel",
+    "anciennesCommunes": [
+      {
+        "code": "56138",
+        "nom": "Monterrein"
+      },
+      {
+        "code": "56165",
+        "nom": "Ploërmel"
+      }
+    ]
+  },
+  {
+    "code": "56173",
+    "nom": "Pluméliau-Bieuzy",
+    "anciennesCommunes": [
+      {
+        "code": "56016",
+        "nom": "Bieuzy"
+      },
+      {
+        "code": "56173",
+        "nom": "Pluméliau"
+      }
+    ]
+  },
+  {
+    "code": "56197",
+    "nom": "Val d'Oust",
+    "anciennesCommunes": [
+      {
+        "code": "56037",
+        "nom": "La Chapelle-Caro"
+      },
+      {
+        "code": "56187",
+        "nom": "Quily"
+      },
+      {
+        "code": "56197",
+        "nom": "Le Roc-Saint-André"
+      }
+    ]
+  },
+  {
+    "code": "56213",
+    "nom": "Saint-Gérand-Croixanvec",
+    "anciennesCommunes": [
+      {
+        "code": "56049",
+        "nom": "Croixanvec"
+      },
+      {
+        "code": "56213",
+        "nom": "Saint-Gérand"
+      }
+    ]
+  },
+  {
+    "code": "56251",
+    "nom": "Theix-Noyalo",
+    "anciennesCommunes": [
+      {
+        "code": "56150",
+        "nom": "Noyalo"
+      },
+      {
+        "code": "56251",
+        "nom": "Theix"
+      }
+    ]
+  },
+  {
+    "code": "57021",
+    "nom": "Ancy-Dornot",
+    "anciennesCommunes": [
+      {
+        "code": "57021",
+        "nom": "Ancy-sur-Moselle"
+      },
+      {
+        "code": "57184",
+        "nom": "Dornot"
+      }
+    ]
+  },
+  {
+    "code": "57148",
+    "nom": "Colligny-Maizery",
+    "anciennesCommunes": [
+      {
+        "code": "57148",
+        "nom": "Colligny"
+      },
+      {
+        "code": "57432",
+        "nom": "Maizery"
+      }
+    ]
+  },
+  {
+    "code": "57439",
+    "nom": "Manderen-Ritzing",
+    "anciennesCommunes": [
+      {
+        "code": "57439",
+        "nom": "Manderen"
+      },
+      {
+        "code": "57585",
+        "nom": "Ritzing"
+      }
+    ]
+  },
+  {
+    "code": "57463",
+    "nom": "Metz",
+    "anciennesCommunes": [
+      {
+        "code": "57463",
+        "nom": "Metz"
+      }
+    ]
+  },
+  {
+    "code": "57482",
+    "nom": "Ogy-Montoy-Flanville",
+    "anciennesCommunes": [
+      {
+        "code": "57482",
+        "nom": "Montoy-Flanville"
+      },
+      {
+        "code": "57523",
+        "nom": "Ogy"
+      }
+    ]
+  },
+  {
+    "code": "57578",
+    "nom": "Rezonville-Vionville",
+    "anciennesCommunes": [
+      {
+        "code": "57578",
+        "nom": "Rezonville"
+      },
+      {
+        "code": "57722",
+        "nom": "Vionville"
+      }
+    ]
+  },
+  {
+    "code": "57695",
+    "nom": "Varize-Vaudoncourt",
+    "anciennesCommunes": [
+      {
+        "code": "57695",
+        "nom": "Varize"
+      }
+    ]
+  },
+  {
+    "code": "58026",
+    "nom": "Beaulieu",
+    "anciennesCommunes": [
+      {
+        "code": "58026",
+        "nom": "Beaulieu"
+      },
+      {
+        "code": "58100",
+        "nom": "Dompierre-sur-Héry"
+      },
+      {
+        "code": "58167",
+        "nom": "Michaugues"
+      }
+    ]
+  },
+  {
+    "code": "58086",
+    "nom": "Cosne-Cours-sur-Loire",
+    "anciennesCommunes": [
+      {
+        "code": "58086",
+        "nom": "Cosne-Cours-sur-Loire"
+      }
+    ]
+  },
+  {
+    "code": "58204",
+    "nom": "Vaux d'Amognes",
+    "anciennesCommunes": [
+      {
+        "code": "58022",
+        "nom": "Balleray"
+      },
+      {
+        "code": "58204",
+        "nom": "Ourouër"
+      }
+    ]
+  },
+  {
+    "code": "59006",
+    "nom": "L'Orée de Mormal",
+    "anciennesCommunes": [
+      {
+        "code": "59006",
+        "nom": "Amfroipret"
+      },
+      {
+        "code": "59070",
+        "nom": "Bermeries"
+      }
+    ]
+  },
+  {
+    "code": "59183",
+    "nom": "Dunkerque",
+    "anciennesCommunes": [
+      {
+        "code": "59183",
+        "nom": "Dunkerque"
+      },
+      {
+        "code": "59248",
+        "nom": "Fort-Mardyck"
+      },
+      {
+        "code": "59540",
+        "nom": "Saint-Pol-sur-Mer"
+      }
+    ]
+  },
+  {
+    "code": "59260",
+    "nom": "Ghyvelde",
+    "anciennesCommunes": [
+      {
+        "code": "59260",
+        "nom": "Ghyvelde"
+      },
+      {
+        "code": "59404",
+        "nom": "Les Moëres"
+      }
+    ]
+  },
+  {
+    "code": "59588",
+    "nom": "Téteghem-Coudekerque-Village",
+    "anciennesCommunes": [
+      {
+        "code": "59154",
+        "nom": "Coudekerque-Village"
+      },
+      {
+        "code": "59588",
+        "nom": "Téteghem"
+      }
+    ]
+  },
+  {
+    "code": "60029",
+    "nom": "Auneuil",
+    "anciennesCommunes": [
+      {
+        "code": "60029",
+        "nom": "Auneuil"
+      },
+      {
+        "code": "60649",
+        "nom": "Troussures"
+      }
+    ]
+  },
+  {
+    "code": "60054",
+    "nom": "Beaumont-les-Nonains",
+    "anciennesCommunes": [
+      {
+        "code": "60054",
+        "nom": "Beaumont-les-Nonains"
+      },
+      {
+        "code": "60455",
+        "nom": "La Neuville-Garnier"
+      },
+      {
+        "code": "60694",
+        "nom": "Villotran"
+      }
+    ]
+  },
+  {
+    "code": "60088",
+    "nom": "Bornel",
+    "anciennesCommunes": [
+      {
+        "code": "60018",
+        "nom": "Anserville"
+      },
+      {
+        "code": "60088",
+        "nom": "Bornel"
+      },
+      {
+        "code": "60246",
+        "nom": "Fosseuse"
+      }
+    ]
+  },
+  {
+    "code": "60196",
+    "nom": "La Drenne",
+    "anciennesCommunes": [
+      {
+        "code": "60196",
+        "nom": "Le Déluge"
+      },
+      {
+        "code": "60453",
+        "nom": "La Neuville-d'Aumont"
+      },
+      {
+        "code": "60532",
+        "nom": "Ressons-l'Abbaye"
+      }
+    ]
+  },
+  {
+    "code": "60209",
+    "nom": "La Corne-en-Vexin",
+    "anciennesCommunes": [
+      {
+        "code": "60080",
+        "nom": "Boissy-le-Bois"
+      },
+      {
+        "code": "60209",
+        "nom": "Énencourt-le-Sec"
+      },
+      {
+        "code": "60300",
+        "nom": "Hardivillers-en-Vexin"
+      }
+    ]
+  },
+  {
+    "code": "60245",
+    "nom": "Formerie",
+    "anciennesCommunes": [
+      {
+        "code": "60096",
+        "nom": "Boutavent"
+      },
+      {
+        "code": "60245",
+        "nom": "Formerie"
+      }
+    ]
+  },
+  {
+    "code": "60256",
+    "nom": "Montchevreuil",
+    "anciennesCommunes": [
+      {
+        "code": "60038",
+        "nom": "Bachivillers"
+      },
+      {
+        "code": "60256",
+        "nom": "Fresneaux-Montchevreuil"
+      }
+    ]
+  },
+  {
+    "code": "60570",
+    "nom": "Saint-Crépin-Ibouvillers",
+    "anciennesCommunes": [
+      {
+        "code": "60417",
+        "nom": "Montherlant"
+      },
+      {
+        "code": "60570",
+        "nom": "Saint-Crépin-Ibouvillers"
+      }
+    ]
+  },
+  {
+    "code": "60644",
+    "nom": "Trie-Château",
+    "anciennesCommunes": [
+      {
+        "code": "60644",
+        "nom": "Trie-Château"
+      },
+      {
+        "code": "60690",
+        "nom": "Villers-sur-Trie"
+      }
+    ]
+  },
+  {
+    "code": "60668",
+    "nom": "Verderel-lès-Sauqueuse",
+    "anciennesCommunes": [
+      {
+        "code": "60668",
+        "nom": "Verderel-lès-Sauqueuse"
+      }
+    ]
+  },
+  {
+    "code": "60682",
+    "nom": "Villers-Saint-Frambourg-Ognon",
+    "anciennesCommunes": [
+      {
+        "code": "60475",
+        "nom": "Ognon"
+      },
+      {
+        "code": "60682",
+        "nom": "Villers-Saint-Frambourg"
+      }
+    ]
+  },
+  {
+    "code": "61007",
+    "nom": "Athis-Val de Rouvre",
+    "anciennesCommunes": [
+      {
+        "code": "61007",
+        "nom": "Athis-de-l'Orne"
+      },
+      {
+        "code": "61058",
+        "nom": "Bréel"
+      },
+      {
+        "code": "61073",
+        "nom": "La Carneille"
+      },
+      {
+        "code": "61313",
+        "nom": "Notre-Dame-du-Rocher"
+      },
+      {
+        "code": "61353",
+        "nom": "Ronfeugerai"
+      },
+      {
+        "code": "61465",
+        "nom": "Ségrie-Fontaine"
+      },
+      {
+        "code": "61478",
+        "nom": "Taillebois"
+      },
+      {
+        "code": "61489",
+        "nom": "Les Tourailles"
+      }
+    ]
+  },
+  {
+    "code": "61050",
+    "nom": "Cour-Maugis sur Huisne",
+    "anciennesCommunes": [
+      {
+        "code": "61050",
+        "nom": "Boissy-Maugis"
+      },
+      {
+        "code": "61128",
+        "nom": "Courcerault"
+      },
+      {
+        "code": "61245",
+        "nom": "Maison-Maugis"
+      },
+      {
+        "code": "61430",
+        "nom": "Saint-Maurice-sur-Huisne"
+      }
+    ]
+  },
+  {
+    "code": "61081",
+    "nom": "Chailloué",
+    "anciennesCommunes": [
+      {
+        "code": "61081",
+        "nom": "Chailloué"
+      },
+      {
+        "code": "61253",
+        "nom": "Marmouillé"
+      },
+      {
+        "code": "61306",
+        "nom": "Neuville-près-Sées"
+      }
+    ]
+  },
+  {
+    "code": "61096",
+    "nom": "Rives d'Andaine",
+    "anciennesCommunes": [
+      {
+        "code": "61096",
+        "nom": "La Chapelle-d'Andaine"
+      },
+      {
+        "code": "61135",
+        "nom": "Couterne"
+      },
+      {
+        "code": "61186",
+        "nom": "Geneslay"
+      },
+      {
+        "code": "61200",
+        "nom": "Haleine"
+      }
+    ]
+  },
+  {
+    "code": "61116",
+    "nom": "Sablons sur Huisne",
+    "anciennesCommunes": [
+      {
+        "code": "61115",
+        "nom": "Condeau"
+      },
+      {
+        "code": "61116",
+        "nom": "Condé-sur-Huisne"
+      },
+      {
+        "code": "61125",
+        "nom": "Coulonges-les-Sablons"
+      }
+    ]
+  },
+  {
+    "code": "61145",
+    "nom": "Domfront en Poiraie",
+    "anciennesCommunes": [
+      {
+        "code": "61145",
+        "nom": "Domfront"
+      },
+      {
+        "code": "61201",
+        "nom": "La Haute-Chapelle"
+      },
+      {
+        "code": "61355",
+        "nom": "Rouellé"
+      }
+    ]
+  },
+  {
+    "code": "61153",
+    "nom": "Écouché-les-Vallées",
+    "anciennesCommunes": [
+      {
+        "code": "61027",
+        "nom": "Batilly"
+      },
+      {
+        "code": "61127",
+        "nom": "La Courbe"
+      },
+      {
+        "code": "61153",
+        "nom": "Écouché"
+      },
+      {
+        "code": "61173",
+        "nom": "Fontenai-sur-Orne"
+      },
+      {
+        "code": "61236",
+        "nom": "Loucé"
+      },
+      {
+        "code": "61441",
+        "nom": "Saint-Ouen-sur-Maire"
+      },
+      {
+        "code": "61470",
+        "nom": "Serans"
+      }
+    ]
+  },
+  {
+    "code": "61167",
+    "nom": "La Ferté-en-Ouche",
+    "anciennesCommunes": [
+      {
+        "code": "61003",
+        "nom": "Anceins"
+      },
+      {
+        "code": "61047",
+        "nom": "Bocquencé"
+      },
+      {
+        "code": "61136",
+        "nom": "Couvains"
+      },
+      {
+        "code": "61167",
+        "nom": "La Ferté-Frênel"
+      },
+      {
+        "code": "61184",
+        "nom": "Gauville"
+      },
+      {
+        "code": "61191",
+        "nom": "Glos-la-Ferrière"
+      },
+      {
+        "code": "61205",
+        "nom": "Heugon"
+      },
+      {
+        "code": "61282",
+        "nom": "Monnai"
+      },
+      {
+        "code": "61434",
+        "nom": "Saint-Nicolas-des-Laitiers"
+      },
+      {
+        "code": "61506",
+        "nom": "Villers-en-Ouche"
+      }
+    ]
+  },
+  {
+    "code": "61168",
+    "nom": "La Ferté Macé",
+    "anciennesCommunes": [
+      {
+        "code": "61004",
+        "nom": "Antoigny"
+      },
+      {
+        "code": "61168",
+        "nom": "La Ferté-Macé"
+      }
+    ]
+  },
+  {
+    "code": "61194",
+    "nom": "Monts-sur-Orne",
+    "anciennesCommunes": [
+      {
+        "code": "61194",
+        "nom": "Goulet"
+      },
+      {
+        "code": "61285",
+        "nom": "Montgaroult"
+      },
+      {
+        "code": "61468",
+        "nom": "Sentilly"
+      }
+    ]
+  },
+  {
+    "code": "61196",
+    "nom": "Belforêt-en-Perche",
+    "anciennesCommunes": [
+      {
+        "code": "61154",
+        "nom": "Eperrais"
+      },
+      {
+        "code": "61196",
+        "nom": "Le Gué-de-la-Chaîne"
+      },
+      {
+        "code": "61318",
+        "nom": "Origny-le-Butin"
+      },
+      {
+        "code": "61325",
+        "nom": "La Perrière"
+      },
+      {
+        "code": "61437",
+        "nom": "Saint-Ouen-de-la-Cour"
+      },
+      {
+        "code": "61471",
+        "nom": "Sérigny"
+      }
+    ]
+  },
+  {
+    "code": "61211",
+    "nom": "Juvigny Val d'Andaine",
+    "anciennesCommunes": [
+      {
+        "code": "61025",
+        "nom": "La Baroche-sous-Lucé"
+      },
+      {
+        "code": "61033",
+        "nom": "Beaulandais"
+      },
+      {
+        "code": "61211",
+        "nom": "Juvigny-sous-Andaine"
+      },
+      {
+        "code": "61235",
+        "nom": "Loré"
+      },
+      {
+        "code": "61239",
+        "nom": "Lucé"
+      },
+      {
+        "code": "61380",
+        "nom": "Saint-Denis-de-Villenette"
+      },
+      {
+        "code": "61469",
+        "nom": "Sept-Forges"
+      }
+    ]
+  },
+  {
+    "code": "61228",
+    "nom": "L'Orée-d'Écouves",
+    "anciennesCommunes": [
+      {
+        "code": "61172",
+        "nom": "Fontenai-les-Louvets"
+      },
+      {
+        "code": "61228",
+        "nom": "Livaie"
+      },
+      {
+        "code": "61231",
+        "nom": "Longuenoë"
+      },
+      {
+        "code": "61383",
+        "nom": "Saint-Didier-sous-Écouves"
+      }
+    ]
+  },
+  {
+    "code": "61230",
+    "nom": "Longny les Villages",
+    "anciennesCommunes": [
+      {
+        "code": "61220",
+        "nom": "La Lande-sur-Eure"
+      },
+      {
+        "code": "61230",
+        "nom": "Longny-au-Perche"
+      },
+      {
+        "code": "61247",
+        "nom": "Malétable"
+      },
+      {
+        "code": "61250",
+        "nom": "Marchainville"
+      },
+      {
+        "code": "61280",
+        "nom": "Monceaux-au-Perche"
+      },
+      {
+        "code": "61296",
+        "nom": "Moulicent"
+      },
+      {
+        "code": "61305",
+        "nom": "Neuilly-sur-Eure"
+      },
+      {
+        "code": "61458",
+        "nom": "Saint-Victor-de-Réno"
+      }
+    ]
+  },
+  {
+    "code": "61275",
+    "nom": "Merlerault-le-Pin",
+    "anciennesCommunes": [
+      {
+        "code": "61017",
+        "nom": "Les Authieux-du-Puits"
+      },
+      {
+        "code": "61188",
+        "nom": "La Genevraie"
+      },
+      {
+        "code": "61192",
+        "nom": "Godisson"
+      },
+      {
+        "code": "61275",
+        "nom": "Le Merlerault"
+      },
+      {
+        "code": "61310",
+        "nom": "Nonant-le-Pin"
+      }
+    ]
+  },
+  {
+    "code": "61292",
+    "nom": "Montsecret-Clairefougère",
+    "anciennesCommunes": [
+      {
+        "code": "61109",
+        "nom": "Clairefougère"
+      },
+      {
+        "code": "61292",
+        "nom": "Montsecret"
+      }
+    ]
+  },
+  {
+    "code": "61294",
+    "nom": "Mortrée",
+    "anciennesCommunes": [
+      {
+        "code": "61294",
+        "nom": "Mortrée"
+      },
+      {
+        "code": "61403",
+        "nom": "Saint-Hilaire-la-Gérard"
+      }
+    ]
+  },
+  {
+    "code": "61309",
+    "nom": "Perche en Nocé",
+    "anciennesCommunes": [
+      {
+        "code": "61112",
+        "nom": "Colonard-Corubert"
+      },
+      {
+        "code": "61144",
+        "nom": "Dancé"
+      },
+      {
+        "code": "61309",
+        "nom": "Nocé"
+      },
+      {
+        "code": "61337",
+        "nom": "Préaux-du-Perche"
+      },
+      {
+        "code": "61368",
+        "nom": "Saint-Aubin-des-Grois"
+      },
+      {
+        "code": "61409",
+        "nom": "Saint-Jean-de-la-Forêt"
+      }
+    ]
+  },
+  {
+    "code": "61324",
+    "nom": "Passais Villages",
+    "anciennesCommunes": [
+      {
+        "code": "61155",
+        "nom": "L'Épinay-le-Comte"
+      },
+      {
+        "code": "61324",
+        "nom": "Passais"
+      },
+      {
+        "code": "61455",
+        "nom": "Saint-Siméon"
+      }
+    ]
+  },
+  {
+    "code": "61339",
+    "nom": "Putanges-le-Lac",
+    "anciennesCommunes": [
+      {
+        "code": "61106",
+        "nom": "Chênedouit"
+      },
+      {
+        "code": "61174",
+        "nom": "La Forêt-Auvray"
+      },
+      {
+        "code": "61179",
+        "nom": "La Fresnaye-au-Sauvage"
+      },
+      {
+        "code": "61270",
+        "nom": "Ménil-Jean"
+      },
+      {
+        "code": "61339",
+        "nom": "Putanges-Pont-Écrepin"
+      },
+      {
+        "code": "61340",
+        "nom": "Rabodanges"
+      },
+      {
+        "code": "61354",
+        "nom": "Les Rotours"
+      },
+      {
+        "code": "61364",
+        "nom": "Saint-Aubert-sur-Orne"
+      },
+      {
+        "code": "61378",
+        "nom": "Sainte-Croix-sur-Orne"
+      }
+    ]
+  },
+  {
+    "code": "61341",
+    "nom": "Écouves",
+    "anciennesCommunes": [
+      {
+        "code": "61175",
+        "nom": "Forges"
+      },
+      {
+        "code": "61341",
+        "nom": "Radon"
+      },
+      {
+        "code": "61509",
+        "nom": "Vingt-Hanaps"
+      }
+    ]
+  },
+  {
+    "code": "61345",
+    "nom": "Rémalard en Perche",
+    "anciennesCommunes": [
+      {
+        "code": "61042",
+        "nom": "Bellou-sur-Huisne"
+      },
+      {
+        "code": "61147",
+        "nom": "Dorceau"
+      },
+      {
+        "code": "61345",
+        "nom": "Rémalard"
+      }
+    ]
+  },
+  {
+    "code": "61375",
+    "nom": "Boischampré",
+    "anciennesCommunes": [
+      {
+        "code": "61249",
+        "nom": "Marcei"
+      },
+      {
+        "code": "61375",
+        "nom": "Saint-Christophe-le-Jajolet"
+      },
+      {
+        "code": "61417",
+        "nom": "Saint-Loyer-des-Champs"
+      },
+      {
+        "code": "61511",
+        "nom": "Vrigny"
+      }
+    ]
+  },
+  {
+    "code": "61429",
+    "nom": "Charencey",
+    "anciennesCommunes": [
+      {
+        "code": "61299",
+        "nom": "Moussonvilliers"
+      },
+      {
+        "code": "61311",
+        "nom": "Normandel"
+      },
+      {
+        "code": "61429",
+        "nom": "Saint-Maurice-lès-Charencey"
+      }
+    ]
+  },
+  {
+    "code": "61460",
+    "nom": "Sap-en-Auge",
+    "anciennesCommunes": [
+      {
+        "code": "61320",
+        "nom": "Orville"
+      },
+      {
+        "code": "61460",
+        "nom": "Le Sap"
+      }
+    ]
+  },
+  {
+    "code": "61463",
+    "nom": "Les Monts d'Andaine",
+    "anciennesCommunes": [
+      {
+        "code": "61428",
+        "nom": "Saint-Maurice-du-Désert"
+      },
+      {
+        "code": "61463",
+        "nom": "La Sauvagère"
+      }
+    ]
+  },
+  {
+    "code": "61474",
+    "nom": "Gouffern en Auge",
+    "anciennesCommunes": [
+      {
+        "code": "61009",
+        "nom": "Aubry-en-Exmes"
+      },
+      {
+        "code": "61019",
+        "nom": "Avernes-sous-Exmes"
+      },
+      {
+        "code": "61057",
+        "nom": "Le Bourg-Saint-Léonard"
+      },
+      {
+        "code": "61083",
+        "nom": "Chambois"
+      },
+      {
+        "code": "61110",
+        "nom": "La Cochère"
+      },
+      {
+        "code": "61131",
+        "nom": "Courménil"
+      },
+      {
+        "code": "61157",
+        "nom": "Exmes"
+      },
+      {
+        "code": "61161",
+        "nom": "Fel"
+      },
+      {
+        "code": "61315",
+        "nom": "Omméel"
+      },
+      {
+        "code": "61449",
+        "nom": "Saint-Pierre-la-Rivière"
+      },
+      {
+        "code": "61474",
+        "nom": "Silly-en-Gouffern"
+      },
+      {
+        "code": "61477",
+        "nom": "Survie"
+      },
+      {
+        "code": "61496",
+        "nom": "Urou-et-Crennes"
+      },
+      {
+        "code": "61504",
+        "nom": "Villebadin"
+      }
+    ]
+  },
+  {
+    "code": "61483",
+    "nom": "Bagnoles de l'Orne Normandie",
+    "anciennesCommunes": [
+      {
+        "code": "61431",
+        "nom": "Saint-Michel-des-Andaines"
+      },
+      {
+        "code": "61483",
+        "nom": "Bagnoles-de-l'Orne"
+      }
+    ]
+  },
+  {
+    "code": "61484",
+    "nom": "Val-au-Perche",
+    "anciennesCommunes": [
+      {
+        "code": "61185",
+        "nom": "Gémages"
+      },
+      {
+        "code": "61204",
+        "nom": "L'Hermitière"
+      },
+      {
+        "code": "61246",
+        "nom": "Mâle"
+      },
+      {
+        "code": "61356",
+        "nom": "La Rouge"
+      },
+      {
+        "code": "61359",
+        "nom": "Saint-Agnan-sur-Erre"
+      },
+      {
+        "code": "61484",
+        "nom": "Le Theil"
+      }
+    ]
+  },
+  {
+    "code": "61486",
+    "nom": "Tinchebray-Bocage",
+    "anciennesCommunes": [
+      {
+        "code": "61031",
+        "nom": "Beauchêne"
+      },
+      {
+        "code": "61177",
+        "nom": "Frênes"
+      },
+      {
+        "code": "61223",
+        "nom": "Larchamp"
+      },
+      {
+        "code": "61377",
+        "nom": "Saint-Cornier-des-Landes"
+      },
+      {
+        "code": "61410",
+        "nom": "Saint-Jean-des-Bois"
+      },
+      {
+        "code": "61486",
+        "nom": "Tinchebray"
+      },
+      {
+        "code": "61513",
+        "nom": "Yvrandes"
+      }
+    ]
+  },
+  {
+    "code": "61491",
+    "nom": "Tourouvre au Perche",
+    "anciennesCommunes": [
+      {
+        "code": "61016",
+        "nom": "Autheuil"
+      },
+      {
+        "code": "61045",
+        "nom": "Bivilliers"
+      },
+      {
+        "code": "61059",
+        "nom": "Bresolettes"
+      },
+      {
+        "code": "61065",
+        "nom": "Bubertré"
+      },
+      {
+        "code": "61090",
+        "nom": "Champs"
+      },
+      {
+        "code": "61226",
+        "nom": "Lignerolles"
+      },
+      {
+        "code": "61335",
+        "nom": "La Poterie-au-Perche"
+      },
+      {
+        "code": "61338",
+        "nom": "Prépotin"
+      },
+      {
+        "code": "61343",
+        "nom": "Randonnai"
+      },
+      {
+        "code": "61491",
+        "nom": "Tourouvre"
+      }
+    ]
+  },
+  {
+    "code": "62154",
+    "nom": "Bonnières",
+    "anciennesCommunes": [
+      {
+        "code": "62154",
+        "nom": "Bonnières"
+      },
+      {
+        "code": "62210",
+        "nom": "Canteleux"
+      }
+    ]
+  },
+  {
+    "code": "62295",
+    "nom": "Enquin-lez-Guinegatte",
+    "anciennesCommunes": [
+      {
+        "code": "62294",
+        "nom": "Enguinegatte"
+      },
+      {
+        "code": "62295",
+        "nom": "Enquin-les-Mines"
+      }
+    ]
+  },
+  {
+    "code": "62447",
+    "nom": "Hesdin-la-Forêt",
+    "anciennesCommunes": [
+      {
+        "code": "62447",
+        "nom": "Hesdin"
+      },
+      {
+        "code": "62461",
+        "nom": "Huby-Saint-Leu"
+      },
+      {
+        "code": "62549",
+        "nom": "Marconne"
+      },
+      {
+        "code": "62743",
+        "nom": "Sainte-Austreberthe"
+      }
+    ]
+  },
+  {
+    "code": "62471",
+    "nom": "Bellinghem",
+    "anciennesCommunes": [
+      {
+        "code": "62431",
+        "nom": "Herbelles"
+      },
+      {
+        "code": "62471",
+        "nom": "Inghem"
+      }
+    ]
+  },
+  {
+    "code": "62691",
+    "nom": "Saint-Augustin",
+    "anciennesCommunes": [
+      {
+        "code": "62226",
+        "nom": "Clarques"
+      },
+      {
+        "code": "62691",
+        "nom": "Rebecques"
+      }
+    ]
+  },
+  {
+    "code": "62757",
+    "nom": "Saint-Martin-lez-Tatinghem",
+    "anciennesCommunes": [
+      {
+        "code": "62757",
+        "nom": "Saint-Martin-au-Laërt"
+      },
+      {
+        "code": "62807",
+        "nom": "Tatinghem"
+      }
+    ]
+  },
+  {
+    "code": "63109",
+    "nom": "Les Deux-Rives",
+    "anciennesCommunes": [
+      {
+        "code": "63109",
+        "nom": "Chidrac"
+      },
+      {
+        "code": "63330",
+        "nom": "Saint-Cirgues-sur-Couze"
+      }
+    ]
+  },
+  {
+    "code": "63160",
+    "nom": "Aulhat-Flat",
+    "anciennesCommunes": [
+      {
+        "code": "63018",
+        "nom": "Aulhat-Saint-Privat"
+      },
+      {
+        "code": "63160",
+        "nom": "Flat"
+      }
+    ]
+  },
+  {
+    "code": "63226",
+    "nom": "Mur-sur-Allier",
+    "anciennesCommunes": [
+      {
+        "code": "63133",
+        "nom": "Dallet"
+      },
+      {
+        "code": "63226",
+        "nom": "Mezel"
+      }
+    ]
+  },
+  {
+    "code": "63244",
+    "nom": "Chambaron sur Morge",
+    "anciennesCommunes": [
+      {
+        "code": "63068",
+        "nom": "Cellule"
+      },
+      {
+        "code": "63244",
+        "nom": "La Moutade"
+      }
+    ]
+  },
+  {
+    "code": "63255",
+    "nom": "Nonette-Orsonnette",
+    "anciennesCommunes": [
+      {
+        "code": "63255",
+        "nom": "Nonette"
+      },
+      {
+        "code": "63266",
+        "nom": "Orsonnette"
+      }
+    ]
+  },
+  {
+    "code": "63303",
+    "nom": "Roche-Charles-la-Mayrand",
+    "anciennesCommunes": [
+      {
+        "code": "63303",
+        "nom": "Roche-Charles-la-Mayrand"
+      }
+    ]
+  },
+  {
+    "code": "63335",
+    "nom": "Saint-Diéry",
+    "anciennesCommunes": [
+      {
+        "code": "63127",
+        "nom": "Creste"
+      },
+      {
+        "code": "63335",
+        "nom": "Saint-Diéry"
+      }
+    ]
+  },
+  {
+    "code": "63448",
+    "nom": "Le Vernet-Chaméane",
+    "anciennesCommunes": [
+      {
+        "code": "63078",
+        "nom": "Chaméane"
+      },
+      {
+        "code": "63448",
+        "nom": "Vernet-la-Varenne"
+      }
+    ]
+  },
+  {
+    "code": "64225",
+    "nom": "Ance Féas",
+    "anciennesCommunes": [
+      {
+        "code": "64020",
+        "nom": "Ance"
+      },
+      {
+        "code": "64225",
+        "nom": "Féas"
+      }
+    ]
+  },
+  {
+    "code": "64300",
+    "nom": "Lacq",
+    "anciennesCommunes": [
+      {
+        "code": "64300",
+        "nom": "Lacq"
+      },
+      {
+        "code": "64541",
+        "nom": "Urdès"
+      }
+    ]
+  },
+  {
+    "code": "65081",
+    "nom": "Benqué-Molère",
+    "anciennesCommunes": [
+      {
+        "code": "65081",
+        "nom": "Benqué"
+      },
+      {
+        "code": "65312",
+        "nom": "Molère"
+      }
+    ]
+  },
+  {
+    "code": "65092",
+    "nom": "Beyrède-Jumet-Camous",
+    "anciennesCommunes": [
+      {
+        "code": "65092",
+        "nom": "Beyrède-Jumet"
+      },
+      {
+        "code": "65122",
+        "nom": "Camous"
+      }
+    ]
+  },
+  {
+    "code": "65192",
+    "nom": "Gavarnie-Gèdre",
+    "anciennesCommunes": [
+      {
+        "code": "65188",
+        "nom": "Gavarnie"
+      },
+      {
+        "code": "65192",
+        "nom": "Gèdre"
+      }
+    ]
+  },
+  {
+    "code": "65282",
+    "nom": "Loudenvielle",
+    "anciennesCommunes": [
+      {
+        "code": "65027",
+        "nom": "Armenteule"
+      },
+      {
+        "code": "65282",
+        "nom": "Loudenvielle"
+      }
+    ]
+  },
+  {
+    "code": "65399",
+    "nom": "Saligos",
+    "anciennesCommunes": [
+      {
+        "code": "65399",
+        "nom": "Saligos"
+      },
+      {
+        "code": "65480",
+        "nom": "Vizos"
+      }
+    ]
+  },
+  {
+    "code": "67004",
+    "nom": "Sommerau",
+    "anciennesCommunes": [
+      {
+        "code": "67004",
+        "nom": "Allenwiller"
+      },
+      {
+        "code": "67041",
+        "nom": "Birkenwald"
+      },
+      {
+        "code": "67431",
+        "nom": "Salenthal"
+      },
+      {
+        "code": "67469",
+        "nom": "Singrist"
+      }
+    ]
+  },
+  {
+    "code": "67122",
+    "nom": "Wangenbourg-Engenthal",
+    "anciennesCommunes": [
+      {
+        "code": "67122",
+        "nom": "Wangenbourg-Engenthal"
+      }
+    ]
+  },
+  {
+    "code": "67153",
+    "nom": "Geiswiller-Zœbersdorf",
+    "anciennesCommunes": [
+      {
+        "code": "67153",
+        "nom": "Geiswiller"
+      },
+      {
+        "code": "67560",
+        "nom": "Zœbersdorf"
+      }
+    ]
+  },
+  {
+    "code": "67202",
+    "nom": "Hochfelden",
+    "anciennesCommunes": [
+      {
+        "code": "67202",
+        "nom": "Hochfelden"
+      },
+      {
+        "code": "67439",
+        "nom": "Schaffhouse-sur-Zorn"
+      }
+    ]
+  },
+  {
+    "code": "67372",
+    "nom": "Val-de-Moder",
+    "anciennesCommunes": [
+      {
+        "code": "67372",
+        "nom": "Pfaffenhoffen"
+      },
+      {
+        "code": "67402",
+        "nom": "Ringeldorf"
+      },
+      {
+        "code": "67496",
+        "nom": "Uberach"
+      },
+      {
+        "code": "67512",
+        "nom": "La Walck"
+      }
+    ]
+  },
+  {
+    "code": "67418",
+    "nom": "Rountzenheim-Auenheim",
+    "anciennesCommunes": [
+      {
+        "code": "67014",
+        "nom": "Auenheim"
+      },
+      {
+        "code": "67418",
+        "nom": "Rountzenheim"
+      }
+    ]
+  },
+  {
+    "code": "67495",
+    "nom": "Truchtersheim",
+    "anciennesCommunes": [
+      {
+        "code": "67374",
+        "nom": "Pfettisheim"
+      },
+      {
+        "code": "67495",
+        "nom": "Truchtersheim"
+      }
+    ]
+  },
+  {
+    "code": "67539",
+    "nom": "Wingersheim les Quatre Bans",
+    "anciennesCommunes": [
+      {
+        "code": "67158",
+        "nom": "Gingsheim"
+      },
+      {
+        "code": "67207",
+        "nom": "Hohatzenheim"
+      },
+      {
+        "code": "67297",
+        "nom": "Mittelhausen"
+      },
+      {
+        "code": "67539",
+        "nom": "Wingersheim"
+      }
+    ]
+  },
+  {
+    "code": "68006",
+    "nom": "Bernwiller",
+    "anciennesCommunes": [
+      {
+        "code": "68006",
+        "nom": "Ammerzwiller"
+      },
+      {
+        "code": "68031",
+        "nom": "Bernwiller"
+      }
+    ]
+  },
+  {
+    "code": "68012",
+    "nom": "Aspach-Michelbach",
+    "anciennesCommunes": [
+      {
+        "code": "68012",
+        "nom": "Aspach-le-Haut"
+      },
+      {
+        "code": "68206",
+        "nom": "Michelbach"
+      }
+    ]
+  },
+  {
+    "code": "68056",
+    "nom": "Brunstatt-Didenheim",
+    "anciennesCommunes": [
+      {
+        "code": "68056",
+        "nom": "Brunstatt"
+      },
+      {
+        "code": "68070",
+        "nom": "Didenheim"
+      }
+    ]
+  },
+  {
+    "code": "68106",
+    "nom": "Goldbach-Altenbach",
+    "anciennesCommunes": [
+      {
+        "code": "68106",
+        "nom": "Goldbach-Altenbach"
+      }
+    ]
+  },
+  {
+    "code": "68143",
+    "nom": "Porte du Ried",
+    "anciennesCommunes": [
+      {
+        "code": "68143",
+        "nom": "Holtzwihr"
+      },
+      {
+        "code": "68272",
+        "nom": "Riedwihr"
+      }
+    ]
+  },
+  {
+    "code": "68162",
+    "nom": "Kaysersberg Vignoble",
+    "anciennesCommunes": [
+      {
+        "code": "68162",
+        "nom": "Kaysersberg"
+      },
+      {
+        "code": "68164",
+        "nom": "Kientzheim"
+      },
+      {
+        "code": "68310",
+        "nom": "Sigolsheim"
+      }
+    ]
+  },
+  {
+    "code": "68201",
+    "nom": "Masevaux-Niederbruck",
+    "anciennesCommunes": [
+      {
+        "code": "68201",
+        "nom": "Masevaux"
+      },
+      {
+        "code": "68233",
+        "nom": "Niederbruck"
+      }
+    ]
+  },
+  {
+    "code": "68219",
+    "nom": "Le Haut Soultzbach",
+    "anciennesCommunes": [
+      {
+        "code": "68219",
+        "nom": "Mortzwiller"
+      },
+      {
+        "code": "68314",
+        "nom": "Soppe-le-Haut"
+      }
+    ]
+  },
+  {
+    "code": "68240",
+    "nom": "Illtal",
+    "anciennesCommunes": [
+      {
+        "code": "68108",
+        "nom": "Grentzingen"
+      },
+      {
+        "code": "68133",
+        "nom": "Henflingen"
+      },
+      {
+        "code": "68240",
+        "nom": "Oberdorf"
+      }
+    ]
+  },
+  {
+    "code": "68320",
+    "nom": "Spechbach",
+    "anciennesCommunes": [
+      {
+        "code": "68319",
+        "nom": "Spechbach-le-Bas"
+      },
+      {
+        "code": "68320",
+        "nom": "Spechbach-le-Haut"
+      }
+    ]
+  },
+  {
+    "code": "69019",
+    "nom": "Belleville-en-Beaujolais",
+    "anciennesCommunes": [
+      {
+        "code": "69019",
+        "nom": "Belleville"
+      },
+      {
+        "code": "69211",
+        "nom": "Saint-Jean-d'Ardières"
+      }
+    ]
+  },
+  {
+    "code": "69024",
+    "nom": "Val d'Oingt",
+    "anciennesCommunes": [
+      {
+        "code": "69024",
+        "nom": "Le Bois-d'Oingt"
+      },
+      {
+        "code": "69146",
+        "nom": "Oingt"
+      },
+      {
+        "code": "69222",
+        "nom": "Saint-Laurent-d'Oingt"
+      }
+    ]
+  },
+  {
+    "code": "69066",
+    "nom": "Cours",
+    "anciennesCommunes": [
+      {
+        "code": "69066",
+        "nom": "Cours-la-Ville"
+      },
+      {
+        "code": "69158",
+        "nom": "Pont-Trambouze"
+      },
+      {
+        "code": "69247",
+        "nom": "Thel"
+      }
+    ]
+  },
+  {
+    "code": "69135",
+    "nom": "Deux-Grosnes",
+    "anciennesCommunes": [
+      {
+        "code": "69015",
+        "nom": "Avenas"
+      },
+      {
+        "code": "69135",
+        "nom": "Monsols"
+      },
+      {
+        "code": "69150",
+        "nom": "Ouroux"
+      },
+      {
+        "code": "69185",
+        "nom": "Saint-Christophe"
+      },
+      {
+        "code": "69210",
+        "nom": "Saint-Jacques-des-Arrêts"
+      },
+      {
+        "code": "69224",
+        "nom": "Saint-Mamert"
+      },
+      {
+        "code": "69251",
+        "nom": "Trades"
+      }
+    ]
+  },
+  {
+    "code": "69149",
+    "nom": "Oullins-Pierre-Bénite",
+    "anciennesCommunes": [
+      {
+        "code": "69149",
+        "nom": "Oullins"
+      },
+      {
+        "code": "69152",
+        "nom": "Pierre-Bénite"
+      }
+    ]
+  },
+  {
+    "code": "69157",
+    "nom": "Vindry-sur-Turdine",
+    "anciennesCommunes": [
+      {
+        "code": "69073",
+        "nom": "Dareizé"
+      },
+      {
+        "code": "69147",
+        "nom": "Les Olmes"
+      },
+      {
+        "code": "69157",
+        "nom": "Pontcharra-sur-Turdine"
+      },
+      {
+        "code": "69223",
+        "nom": "Saint-Loup"
+      }
+    ]
+  },
+  {
+    "code": "69179",
+    "nom": "Beauvallon",
+    "anciennesCommunes": [
+      {
+        "code": "69048",
+        "nom": "Chassagny"
+      },
+      {
+        "code": "69179",
+        "nom": "Saint-Andéol-le-Château"
+      },
+      {
+        "code": "69213",
+        "nom": "Saint-Jean-de-Touslas"
+      }
+    ]
+  },
+  {
+    "code": "69208",
+    "nom": "Saint-Germain-Nuelles",
+    "anciennesCommunes": [
+      {
+        "code": "69144",
+        "nom": "Nuelles"
+      },
+      {
+        "code": "69208",
+        "nom": "Saint-Germain-sur-l'Arbresle"
+      }
+    ]
+  },
+  {
+    "code": "69228",
+    "nom": "Chabanière",
+    "anciennesCommunes": [
+      {
+        "code": "69195",
+        "nom": "Saint-Didier-sous-Riverie"
+      },
+      {
+        "code": "69228",
+        "nom": "Saint-Maurice-sur-Dargoire"
+      },
+      {
+        "code": "69237",
+        "nom": "Saint-Sorlin"
+      }
+    ]
+  },
+  {
+    "code": "69248",
+    "nom": "Thizy-les-Bourgs",
+    "anciennesCommunes": [
+      {
+        "code": "69025",
+        "nom": "Bourg-de-Thizy"
+      },
+      {
+        "code": "69041",
+        "nom": "La Chapelle-de-Mardore"
+      },
+      {
+        "code": "69128",
+        "nom": "Mardore"
+      },
+      {
+        "code": "69129",
+        "nom": "Marnand"
+      },
+      {
+        "code": "69248",
+        "nom": "Thizy"
+      }
+    ]
+  },
+  {
+    "code": "69255",
+    "nom": "Vaugneray",
+    "anciennesCommunes": [
+      {
+        "code": "69221",
+        "nom": "Saint-Laurent-de-Vaux"
+      },
+      {
+        "code": "69255",
+        "nom": "Vaugneray"
+      }
+    ]
+  },
+  {
+    "code": "70152",
+    "nom": "Colombine",
+    "anciennesCommunes": [
+      {
+        "code": "70152",
+        "nom": "Choye"
+      },
+      {
+        "code": "70557",
+        "nom": "Villefrancon"
+      }
+    ]
+  },
+  {
+    "code": "70180",
+    "nom": "Belles-Fontaines",
+    "anciennesCommunes": [
+      {
+        "code": "70180",
+        "nom": "Courchaton"
+      },
+      {
+        "code": "70264",
+        "nom": "Georfans"
+      },
+      {
+        "code": "70530",
+        "nom": "Vellechevreux-et-Courbenans"
+      }
+    ]
+  },
+  {
+    "code": "70245",
+    "nom": "Fougerolles-Saint-Valbert",
+    "anciennesCommunes": [
+      {
+        "code": "70245",
+        "nom": "Fougerolles"
+      },
+      {
+        "code": "70475",
+        "nom": "Saint-Valbert"
+      }
+    ]
+  },
+  {
+    "code": "70285",
+    "nom": "Héricourt",
+    "anciennesCommunes": [
+      {
+        "code": "70285",
+        "nom": "Héricourt"
+      },
+      {
+        "code": "70497",
+        "nom": "Tavey"
+      }
+    ]
+  },
+  {
+    "code": "70418",
+    "nom": "La Romaine",
+    "anciennesCommunes": [
+      {
+        "code": "70281",
+        "nom": "Greucourt"
+      },
+      {
+        "code": "70418",
+        "nom": "Le Pont-de-Planches"
+      },
+      {
+        "code": "70551",
+        "nom": "Vezet"
+      }
+    ]
+  },
+  {
+    "code": "70489",
+    "nom": "Servance-Miellin",
+    "anciennesCommunes": [
+      {
+        "code": "70345",
+        "nom": "Miellin"
+      },
+      {
+        "code": "70489",
+        "nom": "Servance"
+      }
+    ]
+  },
+  {
+    "code": "70491",
+    "nom": "Seveux-Motey",
+    "anciennesCommunes": [
+      {
+        "code": "70375",
+        "nom": "Motey-sur-Saône"
+      },
+      {
+        "code": "70491",
+        "nom": "Seveux"
+      }
+    ]
+  },
+  {
+    "code": "71014",
+    "nom": "Autun",
+    "anciennesCommunes": [
+      {
+        "code": "71014",
+        "nom": "Autun"
+      }
+    ]
+  },
+  {
+    "code": "71042",
+    "nom": "Bonnay-Saint-Ythaire",
+    "anciennesCommunes": [
+      {
+        "code": "71042",
+        "nom": "Bonnay"
+      },
+      {
+        "code": "71492",
+        "nom": "Saint-Ythaire"
+      }
+    ]
+  },
+  {
+    "code": "71134",
+    "nom": "Navour-sur-Grosne",
+    "anciennesCommunes": [
+      {
+        "code": "71055",
+        "nom": "Brandon"
+      },
+      {
+        "code": "71134",
+        "nom": "Clermain"
+      },
+      {
+        "code": "71304",
+        "nom": "Montagny-sur-Grosne"
+      }
+    ]
+  },
+  {
+    "code": "71204",
+    "nom": "Fragnes-La Loyère",
+    "anciennesCommunes": [
+      {
+        "code": "71204",
+        "nom": "Fragnes"
+      },
+      {
+        "code": "71265",
+        "nom": "La Loyère"
+      }
+    ]
+  },
+  {
+    "code": "71263",
+    "nom": "Louhans",
+    "anciennesCommunes": [
+      {
+        "code": "71263",
+        "nom": "Louhans"
+      }
+    ]
+  },
+  {
+    "code": "71279",
+    "nom": "Le Rousset-Marizy",
+    "anciennesCommunes": [
+      {
+        "code": "71279",
+        "nom": "Marizy"
+      },
+      {
+        "code": "71375",
+        "nom": "Le Rousset"
+      }
+    ]
+  },
+  {
+    "code": "71481",
+    "nom": "Saint-Symphorien-d'Ancelles",
+    "anciennesCommunes": [
+      {
+        "code": "71481",
+        "nom": "Saint-Symphorien-d'Ancelles"
+      }
+    ]
+  },
+  {
+    "code": "71566",
+    "nom": "Verdun-Ciel",
+    "anciennesCommunes": [
+      {
+        "code": "71131",
+        "nom": "Ciel"
+      },
+      {
+        "code": "71566",
+        "nom": "Verdun-sur-le-Doubs"
+      }
+    ]
+  },
+  {
+    "code": "71578",
+    "nom": "Clux-Villeneuve",
+    "anciennesCommunes": [
+      {
+        "code": "71138",
+        "nom": "Clux"
+      },
+      {
+        "code": "71578",
+        "nom": "La Villeneuve"
+      }
+    ]
+  },
+  {
+    "code": "71582",
+    "nom": "La Vineuse sur Fregande",
+    "anciennesCommunes": [
+      {
+        "code": "71180",
+        "nom": "Donzy-le-National"
+      },
+      {
+        "code": "71288",
+        "nom": "Massy"
+      },
+      {
+        "code": "71582",
+        "nom": "La Vineuse"
+      },
+      {
+        "code": "71587",
+        "nom": "Vitry-lès-Cluny"
+      }
+    ]
+  },
+  {
+    "code": "72023",
+    "nom": "Ballon-Saint Mars",
+    "anciennesCommunes": [
+      {
+        "code": "72023",
+        "nom": "Ballon"
+      },
+      {
+        "code": "72301",
+        "nom": "Saint-Mars-sous-Ballon"
+      }
+    ]
+  },
+  {
+    "code": "72025",
+    "nom": "Bazouges Cré sur Loir",
+    "anciennesCommunes": [
+      {
+        "code": "72025",
+        "nom": "Bazouges-sur-le-Loir"
+      },
+      {
+        "code": "72108",
+        "nom": "Cré-sur-Loir"
+      }
+    ]
+  },
+  {
+    "code": "72071",
+    "nom": "Montval-sur-Loir",
+    "anciennesCommunes": [
+      {
+        "code": "72071",
+        "nom": "Château-du-Loir"
+      },
+      {
+        "code": "72203",
+        "nom": "Montabon"
+      },
+      {
+        "code": "72384",
+        "nom": "Vouvray-sur-Loir"
+      }
+    ]
+  },
+  {
+    "code": "72080",
+    "nom": "Cherré-Au",
+    "anciennesCommunes": [
+      {
+        "code": "72080",
+        "nom": "Cherré"
+      },
+      {
+        "code": "72081",
+        "nom": "Cherreau"
+      }
+    ]
+  },
+  {
+    "code": "72128",
+    "nom": "Val-d'Étangson",
+    "anciennesCommunes": [
+      {
+        "code": "72128",
+        "nom": "Évaillé"
+      },
+      {
+        "code": "72304",
+        "nom": "Sainte-Osmane"
+      }
+    ]
+  },
+  {
+    "code": "72137",
+    "nom": "Villeneuve-en-Perseigne",
+    "anciennesCommunes": [
+      {
+        "code": "72069",
+        "nom": "Chassé"
+      },
+      {
+        "code": "72137",
+        "nom": "La Fresnaye-sur-Chédouet"
+      },
+      {
+        "code": "72162",
+        "nom": "Lignières-la-Carelle"
+      },
+      {
+        "code": "72207",
+        "nom": "Montigny"
+      },
+      {
+        "code": "72258",
+        "nom": "Roullée"
+      },
+      {
+        "code": "72318",
+        "nom": "Saint-Rigomer-des-Bois"
+      }
+    ]
+  },
+  {
+    "code": "72138",
+    "nom": "Fresnay-sur-Sarthe",
+    "anciennesCommunes": [
+      {
+        "code": "72097",
+        "nom": "Coulombiers"
+      },
+      {
+        "code": "72138",
+        "nom": "Fresnay-sur-Sarthe"
+      },
+      {
+        "code": "72266",
+        "nom": "Saint-Aubin-de-Locquenay"
+      },
+      {
+        "code": "72284",
+        "nom": "Saint-Germain-sur-Sarthe"
+      }
+    ]
+  },
+  {
+    "code": "72155",
+    "nom": "Laigné-Saint-Gervais",
+    "anciennesCommunes": [
+      {
+        "code": "72155",
+        "nom": "Laigné-en-Belin"
+      },
+      {
+        "code": "72287",
+        "nom": "Saint-Gervais-en-Belin"
+      }
+    ]
+  },
+  {
+    "code": "72176",
+    "nom": "Le Lude",
+    "anciennesCommunes": [
+      {
+        "code": "72117",
+        "nom": "Dissé-sous-le-Lude"
+      },
+      {
+        "code": "72176",
+        "nom": "Le Lude"
+      }
+    ]
+  },
+  {
+    "code": "72189",
+    "nom": "Marolles-les-Braults",
+    "anciennesCommunes": [
+      {
+        "code": "72116",
+        "nom": "Dissé-sous-Ballon"
+      },
+      {
+        "code": "72189",
+        "nom": "Marolles-les-Braults"
+      }
+    ]
+  },
+  {
+    "code": "72219",
+    "nom": "Bernay-Neuvy-en-Champagne",
+    "anciennesCommunes": [
+      {
+        "code": "72033",
+        "nom": "Bernay-en-Champagne"
+      },
+      {
+        "code": "72219",
+        "nom": "Neuvy-en-Champagne"
+      }
+    ]
+  },
+  {
+    "code": "72262",
+    "nom": "Loir en Vallée",
+    "anciennesCommunes": [
+      {
+        "code": "72063",
+        "nom": "La Chapelle-Gaugain"
+      },
+      {
+        "code": "72159",
+        "nom": "Lavenay"
+      },
+      {
+        "code": "72240",
+        "nom": "Poncé-sur-le-Loir"
+      },
+      {
+        "code": "72262",
+        "nom": "Ruillé-sur-Loir"
+      }
+    ]
+  },
+  {
+    "code": "72308",
+    "nom": "Saint-Paterne - Le Chevain",
+    "anciennesCommunes": [
+      {
+        "code": "72082",
+        "nom": "Le Chevain"
+      },
+      {
+        "code": "72308",
+        "nom": "Saint-Paterne"
+      }
+    ]
+  },
+  {
+    "code": "72363",
+    "nom": "Tuffé Val de la Chéronne",
+    "anciennesCommunes": [
+      {
+        "code": "72288",
+        "nom": "Saint-Hilaire-le-Lierru"
+      },
+      {
+        "code": "72363",
+        "nom": "Tuffé"
+      }
+    ]
+  },
+  {
+    "code": "72382",
+    "nom": "Val-de-la-Hune",
+    "anciennesCommunes": [
+      {
+        "code": "72298",
+        "nom": "Saint-Mars-de-Locquenay"
+      },
+      {
+        "code": "72382",
+        "nom": "Volnay"
+      }
+    ]
+  },
+  {
+    "code": "73003",
+    "nom": "Grand-Aigueblanche",
+    "anciennesCommunes": [
+      {
+        "code": "73003",
+        "nom": "Aigueblanche"
+      },
+      {
+        "code": "73045",
+        "nom": "Le Bois"
+      },
+      {
+        "code": "73266",
+        "nom": "Saint-Oyen"
+      }
+    ]
+  },
+  {
+    "code": "73006",
+    "nom": "Aime-la-Plagne",
+    "anciennesCommunes": [
+      {
+        "code": "73006",
+        "nom": "Aime"
+      },
+      {
+        "code": "73126",
+        "nom": "Granier"
+      },
+      {
+        "code": "73169",
+        "nom": "Montgirod"
+      }
+    ]
+  },
+  {
+    "code": "73010",
+    "nom": "Entrelacs",
+    "anciennesCommunes": [
+      {
+        "code": "73010",
+        "nom": "Albens"
+      },
+      {
+        "code": "73062",
+        "nom": "Cessens"
+      },
+      {
+        "code": "73108",
+        "nom": "Épersy"
+      },
+      {
+        "code": "73158",
+        "nom": "Mognard"
+      },
+      {
+        "code": "73238",
+        "nom": "Saint-Germain-la-Chambotte"
+      },
+      {
+        "code": "73239",
+        "nom": "Saint-Girod"
+      }
+    ]
+  },
+  {
+    "code": "73135",
+    "nom": "La Tour-en-Maurienne",
+    "anciennesCommunes": [
+      {
+        "code": "73080",
+        "nom": "Le Châtel"
+      },
+      {
+        "code": "73135",
+        "nom": "Hermillon"
+      },
+      {
+        "code": "73203",
+        "nom": "Pontamafrey-Montpascal"
+      }
+    ]
+  },
+  {
+    "code": "73150",
+    "nom": "La Plagne Tarentaise",
+    "anciennesCommunes": [
+      {
+        "code": "73038",
+        "nom": "Bellentre"
+      },
+      {
+        "code": "73093",
+        "nom": "La Côte-d'Aime"
+      },
+      {
+        "code": "73150",
+        "nom": "Mâcot-la-Plagne"
+      },
+      {
+        "code": "73305",
+        "nom": "Valezan"
+      }
+    ]
+  },
+  {
+    "code": "73151",
+    "nom": "Porte-de-Savoie",
+    "anciennesCommunes": [
+      {
+        "code": "73118",
+        "nom": "Francin"
+      },
+      {
+        "code": "73151",
+        "nom": "Les Marches"
+      }
+    ]
+  },
+  {
+    "code": "73187",
+    "nom": "La Léchère",
+    "anciennesCommunes": [
+      {
+        "code": "73046",
+        "nom": "Bonneval"
+      },
+      {
+        "code": "73112",
+        "nom": "Feissons-sur-Isère"
+      },
+      {
+        "code": "73187",
+        "nom": "La Léchère"
+      }
+    ]
+  },
+  {
+    "code": "73212",
+    "nom": "Val-d'Arc",
+    "anciennesCommunes": [
+      {
+        "code": "73002",
+        "nom": "Aiguebelle"
+      },
+      {
+        "code": "73212",
+        "nom": "Randens"
+      }
+    ]
+  },
+  {
+    "code": "73215",
+    "nom": "Valgelon-La Rochette",
+    "anciennesCommunes": [
+      {
+        "code": "73111",
+        "nom": "Étable"
+      },
+      {
+        "code": "73215",
+        "nom": "La Rochette"
+      }
+    ]
+  },
+  {
+    "code": "73227",
+    "nom": "Courchevel",
+    "anciennesCommunes": [
+      {
+        "code": "73198",
+        "nom": "La Perrière"
+      },
+      {
+        "code": "73227",
+        "nom": "Saint-Bon-Tarentaise"
+      }
+    ]
+  },
+  {
+    "code": "73235",
+    "nom": "Saint François Longchamp",
+    "anciennesCommunes": [
+      {
+        "code": "73163",
+        "nom": "Montaimont"
+      },
+      {
+        "code": "73167",
+        "nom": "Montgellafrey"
+      },
+      {
+        "code": "73235",
+        "nom": "Saint-François-Longchamp"
+      }
+    ]
+  },
+  {
+    "code": "73236",
+    "nom": "Saint-Genix-les-Villages",
+    "anciennesCommunes": [
+      {
+        "code": "73127",
+        "nom": "Gresin"
+      },
+      {
+        "code": "73236",
+        "nom": "Saint-Genix-sur-Guiers"
+      },
+      {
+        "code": "73260",
+        "nom": "Saint-Maurice-de-Rotherens"
+      }
+    ]
+  },
+  {
+    "code": "73257",
+    "nom": "Les Belleville",
+    "anciennesCommunes": [
+      {
+        "code": "73244",
+        "nom": "Saint-Jean-de-Belleville"
+      },
+      {
+        "code": "73257",
+        "nom": "Saint-Martin-de-Belleville"
+      },
+      {
+        "code": "73321",
+        "nom": "Villarlurin"
+      }
+    ]
+  },
+  {
+    "code": "73263",
+    "nom": "Saint-Offenge",
+    "anciennesCommunes": [
+      {
+        "code": "73263",
+        "nom": "Saint-Offenge-Dessous"
+      },
+      {
+        "code": "73264",
+        "nom": "Saint-Offenge-Dessus"
+      }
+    ]
+  },
+  {
+    "code": "73284",
+    "nom": "Salins-Fontaine",
+    "anciennesCommunes": [
+      {
+        "code": "73115",
+        "nom": "Fontaine-le-Puits"
+      },
+      {
+        "code": "73284",
+        "nom": "Salins-les-Thermes"
+      }
+    ]
+  },
+  {
+    "code": "73290",
+    "nom": "Val-Cenis",
+    "anciennesCommunes": [
+      {
+        "code": "73056",
+        "nom": "Bramans"
+      },
+      {
+        "code": "73143",
+        "nom": "Lanslebourg-Mont-Cenis"
+      },
+      {
+        "code": "73144",
+        "nom": "Lanslevillard"
+      },
+      {
+        "code": "73287",
+        "nom": "Sollières-Sardières"
+      },
+      {
+        "code": "73290",
+        "nom": "Termignon"
+      }
+    ]
+  },
+  {
+    "code": "74010",
+    "nom": "Annecy",
+    "anciennesCommunes": [
+      {
+        "code": "74010",
+        "nom": "Annecy"
+      },
+      {
+        "code": "74011",
+        "nom": "Annecy-le-Vieux"
+      },
+      {
+        "code": "74093",
+        "nom": "Cran-Gevrier"
+      },
+      {
+        "code": "74182",
+        "nom": "Meythet"
+      },
+      {
+        "code": "74217",
+        "nom": "Pringy"
+      },
+      {
+        "code": "74268",
+        "nom": "Seynod"
+      }
+    ]
+  },
+  {
+    "code": "74112",
+    "nom": "Epagny Metz-Tessy",
+    "anciennesCommunes": [
+      {
+        "code": "74112",
+        "nom": "Épagny"
+      },
+      {
+        "code": "74181",
+        "nom": "Metz-Tessy"
+      }
+    ]
+  },
+  {
+    "code": "74123",
+    "nom": "Faverges-Seythenex",
+    "anciennesCommunes": [
+      {
+        "code": "74123",
+        "nom": "Faverges"
+      },
+      {
+        "code": "74270",
+        "nom": "Seythenex"
+      }
+    ]
+  },
+  {
+    "code": "74167",
+    "nom": "Val de Chaise",
+    "anciennesCommunes": [
+      {
+        "code": "74084",
+        "nom": "Cons-Sainte-Colombe"
+      },
+      {
+        "code": "74167",
+        "nom": "Marlens"
+      }
+    ]
+  },
+  {
+    "code": "74212",
+    "nom": "Glières-Val-de-Borne",
+    "anciennesCommunes": [
+      {
+        "code": "74110",
+        "nom": "Entremont"
+      },
+      {
+        "code": "74212",
+        "nom": "Le Petit-Bornand-les-Glières"
+      }
+    ]
+  },
+  {
+    "code": "74275",
+    "nom": "Talloires-Montmin",
+    "anciennesCommunes": [
+      {
+        "code": "74187",
+        "nom": "Montmin"
+      },
+      {
+        "code": "74275",
+        "nom": "Talloires"
+      }
+    ]
+  },
+  {
+    "code": "74282",
+    "nom": "Fillière",
+    "anciennesCommunes": [
+      {
+        "code": "74022",
+        "nom": "Aviernoz"
+      },
+      {
+        "code": "74120",
+        "nom": "Évires"
+      },
+      {
+        "code": "74204",
+        "nom": "Les Ollières"
+      },
+      {
+        "code": "74245",
+        "nom": "Saint-Martin-Bellevue"
+      },
+      {
+        "code": "74282",
+        "nom": "Thorens-Glières"
+      }
+    ]
+  },
+  {
+    "code": "74289",
+    "nom": "Vallières-sur-Fier",
+    "anciennesCommunes": [
+      {
+        "code": "74274",
+        "nom": "Val-de-Fier"
+      },
+      {
+        "code": "74289",
+        "nom": "Vallières"
+      }
+    ]
+  },
+  {
+    "code": "76034",
+    "nom": "Val-de-Scie",
+    "anciennesCommunes": [
+      {
+        "code": "76034",
+        "nom": "Auffay"
+      },
+      {
+        "code": "76191",
+        "nom": "Cressy"
+      },
+      {
+        "code": "76674",
+        "nom": "Sévis"
+      }
+    ]
+  },
+  {
+    "code": "76041",
+    "nom": "Les Hauts-de-Caux",
+    "anciennesCommunes": [
+      {
+        "code": "76041",
+        "nom": "Autretot"
+      },
+      {
+        "code": "76729",
+        "nom": "Veauville-lès-Baons"
+      }
+    ]
+  },
+  {
+    "code": "76146",
+    "nom": "Buchy",
+    "anciennesCommunes": [
+      {
+        "code": "76127",
+        "nom": "Bosc-Roger-sur-Buchy"
+      },
+      {
+        "code": "76146",
+        "nom": "Buchy"
+      },
+      {
+        "code": "76248",
+        "nom": "Estouteville-Écalles"
+      }
+    ]
+  },
+  {
+    "code": "76164",
+    "nom": "Rives-en-Seine",
+    "anciennesCommunes": [
+      {
+        "code": "76164",
+        "nom": "Caudebec-en-Caux"
+      },
+      {
+        "code": "76659",
+        "nom": "Saint-Wandrille-Rançon"
+      },
+      {
+        "code": "76742",
+        "nom": "Villequier"
+      }
+    ]
+  },
+  {
+    "code": "76258",
+    "nom": "Terres-de-Caux",
+    "anciennesCommunes": [
+      {
+        "code": "76044",
+        "nom": "Auzouville-Auberbosc"
+      },
+      {
+        "code": "76078",
+        "nom": "Bennetot"
+      },
+      {
+        "code": "76080",
+        "nom": "Bermonville"
+      },
+      {
+        "code": "76258",
+        "nom": "Fauville-en-Caux"
+      },
+      {
+        "code": "76525",
+        "nom": "Ricarville"
+      },
+      {
+        "code": "76607",
+        "nom": "Sainte-Marguerite-sur-Fauville"
+      },
+      {
+        "code": "76639",
+        "nom": "Saint-Pierre-Lavis"
+      }
+    ]
+  },
+  {
+    "code": "76276",
+    "nom": "Forges-les-Eaux",
+    "anciennesCommunes": [
+      {
+        "code": "76276",
+        "nom": "Forges-les-Eaux"
+      },
+      {
+        "code": "76277",
+        "nom": "Le Fossé"
+      }
+    ]
+  },
+  {
+    "code": "76289",
+    "nom": "Saint Martin de l'If",
+    "anciennesCommunes": [
+      {
+        "code": "76089",
+        "nom": "Betteville"
+      },
+      {
+        "code": "76267",
+        "nom": "La Folletière"
+      },
+      {
+        "code": "76289",
+        "nom": "Fréville"
+      },
+      {
+        "code": "76444",
+        "nom": "Mont-de-l'If"
+      }
+    ]
+  },
+  {
+    "code": "76401",
+    "nom": "Arelaune-en-Seine",
+    "anciennesCommunes": [
+      {
+        "code": "76401",
+        "nom": "La Mailleraye-sur-Seine"
+      },
+      {
+        "code": "76625",
+        "nom": "Saint-Nicolas-de-Bliquetuit"
+      }
+    ]
+  },
+  {
+    "code": "76455",
+    "nom": "Morville-le-Héron",
+    "anciennesCommunes": [
+      {
+        "code": "76358",
+        "nom": "Le Héron"
+      },
+      {
+        "code": "76455",
+        "nom": "Morville-sur-Andelle"
+      }
+    ]
+  },
+  {
+    "code": "76476",
+    "nom": "Port-Jérôme-sur-Seine",
+    "anciennesCommunes": [
+      {
+        "code": "76031",
+        "nom": "Auberville-la-Campagne"
+      },
+      {
+        "code": "76476",
+        "nom": "Notre-Dame-de-Gravenchon"
+      },
+      {
+        "code": "76701",
+        "nom": "Touffreville-la-Cable"
+      },
+      {
+        "code": "76713",
+        "nom": "Triquerville"
+      }
+    ]
+  },
+  {
+    "code": "76618",
+    "nom": "Petit-Caux",
+    "anciennesCommunes": [
+      {
+        "code": "76027",
+        "nom": "Assigny"
+      },
+      {
+        "code": "76037",
+        "nom": "Auquemesnil"
+      },
+      {
+        "code": "76073",
+        "nom": "Belleville-sur-Mer"
+      },
+      {
+        "code": "76081",
+        "nom": "Berneval-le-Grand"
+      },
+      {
+        "code": "76098",
+        "nom": "Biville-sur-Mer"
+      },
+      {
+        "code": "76137",
+        "nom": "Bracquemont"
+      },
+      {
+        "code": "76145",
+        "nom": "Brunville"
+      },
+      {
+        "code": "76215",
+        "nom": "Derchigny"
+      },
+      {
+        "code": "76301",
+        "nom": "Glicourt"
+      },
+      {
+        "code": "76310",
+        "nom": "Gouchaupre"
+      },
+      {
+        "code": "76326",
+        "nom": "Greny"
+      },
+      {
+        "code": "76337",
+        "nom": "Guilmécourt"
+      },
+      {
+        "code": "76376",
+        "nom": "Intraville"
+      },
+      {
+        "code": "76496",
+        "nom": "Penly"
+      },
+      {
+        "code": "76618",
+        "nom": "Saint-Martin-en-Campagne"
+      },
+      {
+        "code": "76643",
+        "nom": "Saint-Quentin-au-Bosc"
+      },
+      {
+        "code": "76696",
+        "nom": "Tocqueville-sur-Eu"
+      },
+      {
+        "code": "76704",
+        "nom": "Tourville-la-Chapelle"
+      }
+    ]
+  },
+  {
+    "code": "77109",
+    "nom": "Chenoise-Cucharmoy",
+    "anciennesCommunes": [
+      {
+        "code": "77109",
+        "nom": "Chenoise"
+      },
+      {
+        "code": "77149",
+        "nom": "Cucharmoy"
+      }
+    ]
+  },
+  {
+    "code": "77262",
+    "nom": "Louan-Villegruis-Fontaine",
+    "anciennesCommunes": [
+      {
+        "code": "77262",
+        "nom": "Louan-Villegruis-Fontaine"
+      }
+    ]
+  },
+  {
+    "code": "77316",
+    "nom": "Moret-Loing-et-Orvanne",
+    "anciennesCommunes": [
+      {
+        "code": "77166",
+        "nom": "Écuelles"
+      },
+      {
+        "code": "77170",
+        "nom": "Épisy"
+      },
+      {
+        "code": "77299",
+        "nom": "Montarlot"
+      },
+      {
+        "code": "77316",
+        "nom": "Moret-sur-Loing"
+      },
+      {
+        "code": "77491",
+        "nom": "Veneux-les-Sablons"
+      }
+    ]
+  },
+  {
+    "code": "77433",
+    "nom": "Beautheil-Saints",
+    "anciennesCommunes": [
+      {
+        "code": "77028",
+        "nom": "Beautheil"
+      },
+      {
+        "code": "77433",
+        "nom": "Saints"
+      }
+    ]
+  },
+  {
+    "code": "77504",
+    "nom": "Villemaréchal",
+    "anciennesCommunes": [
+      {
+        "code": "77399",
+        "nom": "Saint-Ange-le-Viel"
+      },
+      {
+        "code": "77504",
+        "nom": "Villemaréchal"
+      }
+    ]
+  },
+  {
+    "code": "78158",
+    "nom": "Le Chesnay-Rocquencourt",
+    "anciennesCommunes": [
+      {
+        "code": "78158",
+        "nom": "Le Chesnay"
+      },
+      {
+        "code": "78524",
+        "nom": "Rocquencourt"
+      }
+    ]
+  },
+  {
+    "code": "78320",
+    "nom": "Notre-Dame-de-la-Mer",
+    "anciennesCommunes": [
+      {
+        "code": "78320",
+        "nom": "Jeufosse"
+      },
+      {
+        "code": "78503",
+        "nom": "Port-Villez"
+      }
+    ]
+  },
+  {
+    "code": "78551",
+    "nom": "Saint-Germain-en-Laye",
+    "anciennesCommunes": [
+      {
+        "code": "78251",
+        "nom": "Fourqueux"
+      },
+      {
+        "code": "78551",
+        "nom": "Saint-Germain-en-Laye"
+      }
+    ]
+  },
+  {
+    "code": "79005",
+    "nom": "Airvault",
+    "anciennesCommunes": [
+      {
+        "code": "79005",
+        "nom": "Airvault"
+      },
+      {
+        "code": "79325",
+        "nom": "Tessonnière"
+      }
+    ]
+  },
+  {
+    "code": "79013",
+    "nom": "Argentonnay",
+    "anciennesCommunes": [
+      {
+        "code": "79013",
+        "nom": "Argenton-les-Vallées"
+      },
+      {
+        "code": "79053",
+        "nom": "Le Breuil-sous-Argenton"
+      },
+      {
+        "code": "79072",
+        "nom": "La Chapelle-Gaudin"
+      },
+      {
+        "code": "79099",
+        "nom": "La Coudre"
+      },
+      {
+        "code": "79187",
+        "nom": "Moutiers-sous-Argenton"
+      },
+      {
+        "code": "79333",
+        "nom": "Ulcot"
+      }
+    ]
+  },
+  {
+    "code": "79014",
+    "nom": "Loretz-d'Argenton",
+    "anciennesCommunes": [
+      {
+        "code": "79014",
+        "nom": "Argenton-l'Église"
+      },
+      {
+        "code": "79043",
+        "nom": "Bouillé-Loretz"
+      }
+    ]
+  },
+  {
+    "code": "79030",
+    "nom": "Beaussais-Vitré",
+    "anciennesCommunes": [
+      {
+        "code": "79030",
+        "nom": "Beaussais"
+      },
+      {
+        "code": "79353",
+        "nom": "Vitré"
+      }
+    ]
+  },
+  {
+    "code": "79061",
+    "nom": "Celles-sur-Belle",
+    "anciennesCommunes": [
+      {
+        "code": "79061",
+        "nom": "Celles-sur-Belle"
+      },
+      {
+        "code": "79282",
+        "nom": "Saint-Médard"
+      }
+    ]
+  },
+  {
+    "code": "79063",
+    "nom": "Val en Vignes",
+    "anciennesCommunes": [
+      {
+        "code": "79044",
+        "nom": "Bouillé-Saint-Paul"
+      },
+      {
+        "code": "79063",
+        "nom": "Cersay"
+      },
+      {
+        "code": "79168",
+        "nom": "Massais"
+      }
+    ]
+  },
+  {
+    "code": "79064",
+    "nom": "Fontivillié",
+    "anciennesCommunes": [
+      {
+        "code": "79064",
+        "nom": "Chail"
+      },
+      {
+        "code": "79314",
+        "nom": "Sompt"
+      }
+    ]
+  },
+  {
+    "code": "79066",
+    "nom": "Champdeniers",
+    "anciennesCommunes": [
+      {
+        "code": "79066",
+        "nom": "Champdeniers-Saint-Denis"
+      }
+    ]
+  },
+  {
+    "code": "79077",
+    "nom": "Beugnon-Thireuil",
+    "anciennesCommunes": [
+      {
+        "code": "79035",
+        "nom": "Le Beugnon"
+      },
+      {
+        "code": "79077",
+        "nom": "La Chapelle-Thireuil"
+      }
+    ]
+  },
+  {
+    "code": "79078",
+    "nom": "Plaine-d'Argenson",
+    "anciennesCommunes": [
+      {
+        "code": "79033",
+        "nom": "Belleville"
+      },
+      {
+        "code": "79039",
+        "nom": "Boisserolles"
+      },
+      {
+        "code": "79078",
+        "nom": "Prissé-la-Charrière"
+      },
+      {
+        "code": "79247",
+        "nom": "Saint-Étienne-la-Cigogne"
+      }
+    ]
+  },
+  {
+    "code": "79083",
+    "nom": "Chef-Boutonne",
+    "anciennesCommunes": [
+      {
+        "code": "79027",
+        "nom": "La Bataille"
+      },
+      {
+        "code": "79083",
+        "nom": "Chef-Boutonne"
+      },
+      {
+        "code": "79107",
+        "nom": "Crézières"
+      },
+      {
+        "code": "79330",
+        "nom": "Tillou"
+      }
+    ]
+  },
+  {
+    "code": "79105",
+    "nom": "Les Châteliers",
+    "anciennesCommunes": [
+      {
+        "code": "79068",
+        "nom": "Chantecorps"
+      },
+      {
+        "code": "79105",
+        "nom": "Coutières"
+      }
+    ]
+  },
+  {
+    "code": "79136",
+    "nom": "Alloinay",
+    "anciennesCommunes": [
+      {
+        "code": "79006",
+        "nom": "Les Alleuds"
+      },
+      {
+        "code": "79136",
+        "nom": "Gournay-Loizé"
+      }
+    ]
+  },
+  {
+    "code": "79140",
+    "nom": "Valdelaume",
+    "anciennesCommunes": [
+      {
+        "code": "79011",
+        "nom": "Ardilleux"
+      },
+      {
+        "code": "79045",
+        "nom": "Bouin"
+      },
+      {
+        "code": "79140",
+        "nom": "Hanc"
+      },
+      {
+        "code": "79211",
+        "nom": "Pioussay"
+      }
+    ]
+  },
+  {
+    "code": "79174",
+    "nom": "Melle",
+    "anciennesCommunes": [
+      {
+        "code": "79173",
+        "nom": "Mazières-sur-Béronne"
+      },
+      {
+        "code": "79174",
+        "nom": "Melle"
+      },
+      {
+        "code": "79199",
+        "nom": "Paizay-le-Tort"
+      },
+      {
+        "code": "79264",
+        "nom": "Saint-Léger-de-la-Martinière"
+      },
+      {
+        "code": "79279",
+        "nom": "Saint-Martin-lès-Melle"
+      }
+    ]
+  },
+  {
+    "code": "79179",
+    "nom": "Moncoutant-sur-Sèvre",
+    "anciennesCommunes": [
+      {
+        "code": "79051",
+        "nom": "Le Breuil-Bernard"
+      },
+      {
+        "code": "79075",
+        "nom": "La Chapelle-Saint-Étienne"
+      },
+      {
+        "code": "79179",
+        "nom": "Moncoutant"
+      },
+      {
+        "code": "79188",
+        "nom": "Moutiers-sous-Chantemerle"
+      },
+      {
+        "code": "79222",
+        "nom": "Pugny"
+      },
+      {
+        "code": "79261",
+        "nom": "Saint-Jouin-de-Milly"
+      }
+    ]
+  },
+  {
+    "code": "79185",
+    "nom": "Aigondigné",
+    "anciennesCommunes": [
+      {
+        "code": "79004",
+        "nom": "Aigonnay"
+      },
+      {
+        "code": "79185",
+        "nom": "Mougon"
+      },
+      {
+        "code": "79240",
+        "nom": "Sainte-Blandine"
+      },
+      {
+        "code": "79327",
+        "nom": "Thorigné"
+      }
+    ]
+  },
+  {
+    "code": "79196",
+    "nom": "Plaine-et-Vallées",
+    "anciennesCommunes": [
+      {
+        "code": "79054",
+        "nom": "Brie"
+      },
+      {
+        "code": "79196",
+        "nom": "Oiron"
+      },
+      {
+        "code": "79260",
+        "nom": "Saint-Jouin-de-Marnes"
+      },
+      {
+        "code": "79321",
+        "nom": "Taizé-Maulais"
+      }
+    ]
+  },
+  {
+    "code": "79217",
+    "nom": "Prailles-La Couarde",
+    "anciennesCommunes": [
+      {
+        "code": "79098",
+        "nom": "La Couarde"
+      },
+      {
+        "code": "79217",
+        "nom": "Prailles"
+      }
+    ]
+  },
+  {
+    "code": "79242",
+    "nom": "Voulmentin",
+    "anciennesCommunes": [
+      {
+        "code": "79242",
+        "nom": "Saint-Clémentin"
+      },
+      {
+        "code": "79356",
+        "nom": "Voultegon"
+      }
+    ]
+  },
+  {
+    "code": "79251",
+    "nom": "Marcillé",
+    "anciennesCommunes": [
+      {
+        "code": "79214",
+        "nom": "Pouffonds"
+      },
+      {
+        "code": "79251",
+        "nom": "Saint-Génard"
+      }
+    ]
+  },
+  {
+    "code": "79280",
+    "nom": "Saint Maurice Étusson",
+    "anciennesCommunes": [
+      {
+        "code": "79113",
+        "nom": "Étusson"
+      },
+      {
+        "code": "79280",
+        "nom": "Saint-Maurice-la-Fougereuse"
+      }
+    ]
+  },
+  {
+    "code": "79285",
+    "nom": "Saint-Pardoux-Soutiers",
+    "anciennesCommunes": [
+      {
+        "code": "79285",
+        "nom": "Saint-Pardoux"
+      },
+      {
+        "code": "79318",
+        "nom": "Soutiers"
+      }
+    ]
+  },
+  {
+    "code": "79307",
+    "nom": "Sauzé-entre-Bois",
+    "anciennesCommunes": [
+      {
+        "code": "79060",
+        "nom": "Caunay"
+      },
+      {
+        "code": "79180",
+        "nom": "Montalembert"
+      },
+      {
+        "code": "79205",
+        "nom": "Pers"
+      },
+      {
+        "code": "79212",
+        "nom": "Pliboux"
+      },
+      {
+        "code": "79307",
+        "nom": "Sauzé-Vaussais"
+      }
+    ]
+  },
+  {
+    "code": "79329",
+    "nom": "Thouars",
+    "anciennesCommunes": [
+      {
+        "code": "79171",
+        "nom": "Mauzé-Thouarsais"
+      },
+      {
+        "code": "79178",
+        "nom": "Missé"
+      },
+      {
+        "code": "79292",
+        "nom": "Sainte-Radegonde"
+      },
+      {
+        "code": "79329",
+        "nom": "Thouars"
+      }
+    ]
+  },
+  {
+    "code": "79334",
+    "nom": "Val-du-Mignon",
+    "anciennesCommunes": [
+      {
+        "code": "79219",
+        "nom": "Priaires"
+      },
+      {
+        "code": "79328",
+        "nom": "Thorigny-sur-le-Mignon"
+      },
+      {
+        "code": "79334",
+        "nom": "Usseau"
+      }
+    ]
+  },
+  {
+    "code": "80155",
+    "nom": "Bussus-lès-Yaucourt",
+    "anciennesCommunes": [
+      {
+        "code": "80155",
+        "nom": "Bussus-Bussuel"
+      },
+      {
+        "code": "80830",
+        "nom": "Yaucourt-Bussus"
+      }
+    ]
+  },
+  {
+    "code": "80295",
+    "nom": "Étinehem-Méricourt",
+    "anciennesCommunes": [
+      {
+        "code": "80295",
+        "nom": "Étinehem"
+      },
+      {
+        "code": "80532",
+        "nom": "Méricourt-sur-Somme"
+      }
+    ]
+  },
+  {
+    "code": "80442",
+    "nom": "Hombleux",
+    "anciennesCommunes": [
+      {
+        "code": "80389",
+        "nom": "Grécourt"
+      },
+      {
+        "code": "80442",
+        "nom": "Hombleux"
+      }
+    ]
+  },
+  {
+    "code": "80485",
+    "nom": "Ô-de-Selle",
+    "anciennesCommunes": [
+      {
+        "code": "80485",
+        "nom": "Lœuilly"
+      },
+      {
+        "code": "80594",
+        "nom": "Neuville-lès-Lœuilly"
+      },
+      {
+        "code": "80761",
+        "nom": "Tilloy-lès-Conty"
+      }
+    ]
+  },
+  {
+    "code": "80505",
+    "nom": "Carnoy-Mametz",
+    "anciennesCommunes": [
+      {
+        "code": "80175",
+        "nom": "Carnoy"
+      },
+      {
+        "code": "80505",
+        "nom": "Mametz"
+      }
+    ]
+  },
+  {
+    "code": "80509",
+    "nom": "Marchélepot-Misery",
+    "anciennesCommunes": [
+      {
+        "code": "80509",
+        "nom": "Marchélepot"
+      },
+      {
+        "code": "80551",
+        "nom": "Misery"
+      }
+    ]
+  },
+  {
+    "code": "80566",
+    "nom": "Fieffes-Montrelet",
+    "anciennesCommunes": [
+      {
+        "code": "80566",
+        "nom": "Fieffes-Montrelet"
+      }
+    ]
+  },
+  {
+    "code": "80621",
+    "nom": "Hypercourt",
+    "anciennesCommunes": [
+      {
+        "code": "80447",
+        "nom": "Hyencourt-le-Grand"
+      },
+      {
+        "code": "80608",
+        "nom": "Omiécourt"
+      },
+      {
+        "code": "80621",
+        "nom": "Pertain"
+      }
+    ]
+  },
+  {
+    "code": "80625",
+    "nom": "Trois-Rivières",
+    "anciennesCommunes": [
+      {
+        "code": "80209",
+        "nom": "Contoire"
+      },
+      {
+        "code": "80419",
+        "nom": "Hargicourt"
+      },
+      {
+        "code": "80625",
+        "nom": "Pierrepont-sur-Avre"
+      }
+    ]
+  },
+  {
+    "code": "81026",
+    "nom": "Bellegarde-Marsal",
+    "anciennesCommunes": [
+      {
+        "code": "81026",
+        "nom": "Bellegarde"
+      },
+      {
+        "code": "81155",
+        "nom": "Marsal"
+      }
+    ]
+  },
+  {
+    "code": "81062",
+    "nom": "Fontrieu",
+    "anciennesCommunes": [
+      {
+        "code": "81062",
+        "nom": "Castelnau-de-Brassac"
+      },
+      {
+        "code": "81091",
+        "nom": "Ferrières"
+      },
+      {
+        "code": "81153",
+        "nom": "Le Margnès"
+      }
+    ]
+  },
+  {
+    "code": "81218",
+    "nom": "Puygouzon",
+    "anciennesCommunes": [
+      {
+        "code": "81113",
+        "nom": "Labastide-Dénat"
+      },
+      {
+        "code": "81218",
+        "nom": "Puygouzon"
+      }
+    ]
+  },
+  {
+    "code": "81233",
+    "nom": "Terre-de-Bancalié",
+    "anciennesCommunes": [
+      {
+        "code": "81226",
+        "nom": "Ronel"
+      },
+      {
+        "code": "81233",
+        "nom": "Roumégoux"
+      },
+      {
+        "code": "81241",
+        "nom": "Saint-Antonin-de-Lacalm"
+      },
+      {
+        "code": "81260",
+        "nom": "Saint-Lieux-Lafenasse"
+      },
+      {
+        "code": "81296",
+        "nom": "Terre-Clapier"
+      },
+      {
+        "code": "81301",
+        "nom": "Le Travet"
+      }
+    ]
+  },
+  {
+    "code": "85001",
+    "nom": "L'Aiguillon-la-Presqu'île",
+    "anciennesCommunes": [
+      {
+        "code": "85001",
+        "nom": "L'Aiguillon-sur-Mer"
+      },
+      {
+        "code": "85307",
+        "nom": "La Faute-sur-Mer"
+      }
+    ]
+  },
+  {
+    "code": "85008",
+    "nom": "Aubigny-Les Clouzeaux",
+    "anciennesCommunes": [
+      {
+        "code": "85008",
+        "nom": "Aubigny"
+      },
+      {
+        "code": "85069",
+        "nom": "Les Clouzeaux"
+      }
+    ]
+  },
+  {
+    "code": "85009",
+    "nom": "Auchay-sur-Vendée",
+    "anciennesCommunes": [
+      {
+        "code": "85009",
+        "nom": "Auzay"
+      },
+      {
+        "code": "85044",
+        "nom": "Chaix"
+      }
+    ]
+  },
+  {
+    "code": "85019",
+    "nom": "Bellevigny",
+    "anciennesCommunes": [
+      {
+        "code": "85019",
+        "nom": "Belleville-sur-Vie"
+      },
+      {
+        "code": "85279",
+        "nom": "Saligny"
+      }
+    ]
+  },
+  {
+    "code": "85076",
+    "nom": "Cugand-la-Bernardière",
+    "anciennesCommunes": [
+      {
+        "code": "85021",
+        "nom": "La Bernardière"
+      },
+      {
+        "code": "85076",
+        "nom": "Cugand"
+      }
+    ]
+  },
+  {
+    "code": "85080",
+    "nom": "Doix lès Fontaines",
+    "anciennesCommunes": [
+      {
+        "code": "85080",
+        "nom": "Doix"
+      },
+      {
+        "code": "85091",
+        "nom": "Fontaines"
+      }
+    ]
+  },
+  {
+    "code": "85084",
+    "nom": "Essarts-en-Bocage",
+    "anciennesCommunes": [
+      {
+        "code": "85030",
+        "nom": "Boulogne"
+      },
+      {
+        "code": "85084",
+        "nom": "Les Essarts"
+      },
+      {
+        "code": "85165",
+        "nom": "L'Oie"
+      },
+      {
+        "code": "85212",
+        "nom": "Sainte-Florence"
+      }
+    ]
+  },
+  {
+    "code": "85090",
+    "nom": "Sèvremont",
+    "anciennesCommunes": [
+      {
+        "code": "85063",
+        "nom": "Les Châtelliers-Châteaumur"
+      },
+      {
+        "code": "85090",
+        "nom": "La Flocellière"
+      },
+      {
+        "code": "85180",
+        "nom": "La Pommeraie-sur-Sèvre"
+      },
+      {
+        "code": "85257",
+        "nom": "Saint-Michel-Mont-Mercure"
+      }
+    ]
+  },
+  {
+    "code": "85146",
+    "nom": "Montaigu-Vendée",
+    "anciennesCommunes": [
+      {
+        "code": "85027",
+        "nom": "Boufféré"
+      },
+      {
+        "code": "85107",
+        "nom": "La Guyonnière"
+      },
+      {
+        "code": "85146",
+        "nom": "Montaigu"
+      },
+      {
+        "code": "85217",
+        "nom": "Saint-Georges-de-Montaigu"
+      },
+      {
+        "code": "85224",
+        "nom": "Saint-Hilaire-de-Loulay"
+      }
+    ]
+  },
+  {
+    "code": "85152",
+    "nom": "Les Achards",
+    "anciennesCommunes": [
+      {
+        "code": "85052",
+        "nom": "La Chapelle-Achard"
+      },
+      {
+        "code": "85152",
+        "nom": "La Mothe-Achard"
+      }
+    ]
+  },
+  {
+    "code": "85154",
+    "nom": "Mouilleron-Saint-Germain",
+    "anciennesCommunes": [
+      {
+        "code": "85154",
+        "nom": "Mouilleron-en-Pareds"
+      },
+      {
+        "code": "85219",
+        "nom": "Saint-Germain-l'Aiguiller"
+      }
+    ]
+  },
+  {
+    "code": "85162",
+    "nom": "Rives-d'Autise",
+    "anciennesCommunes": [
+      {
+        "code": "85162",
+        "nom": "Nieul-sur-l'Autise"
+      },
+      {
+        "code": "85168",
+        "nom": "Oulmes"
+      }
+    ]
+  },
+  {
+    "code": "85177",
+    "nom": "Les Velluire-sur-Vendée",
+    "anciennesCommunes": [
+      {
+        "code": "85177",
+        "nom": "Le Poiré-sur-Velluire"
+      },
+      {
+        "code": "85299",
+        "nom": "Velluire"
+      }
+    ]
+  },
+  {
+    "code": "85194",
+    "nom": "Les Sables-d'Olonne",
+    "anciennesCommunes": [
+      {
+        "code": "85060",
+        "nom": "Château-d'Olonne"
+      },
+      {
+        "code": "85166",
+        "nom": "Olonne-sur-Mer"
+      },
+      {
+        "code": "85194",
+        "nom": "Les Sables-d'Olonne"
+      }
+    ]
+  },
+  {
+    "code": "85197",
+    "nom": "Montréverd",
+    "anciennesCommunes": [
+      {
+        "code": "85150",
+        "nom": "Mormaison"
+      },
+      {
+        "code": "85197",
+        "nom": "Saint-André-Treize-Voies"
+      },
+      {
+        "code": "85272",
+        "nom": "Saint-Sulpice-le-Verdon"
+      }
+    ]
+  },
+  {
+    "code": "85213",
+    "nom": "Rives de l'Yon",
+    "anciennesCommunes": [
+      {
+        "code": "85043",
+        "nom": "Chaillé-sous-les-Ormeaux"
+      },
+      {
+        "code": "85213",
+        "nom": "Saint-Florent-des-Bois"
+      }
+    ]
+  },
+  {
+    "code": "85223",
+    "nom": "Saint-Jean-d'Hermine",
+    "anciennesCommunes": [
+      {
+        "code": "85223",
+        "nom": "Sainte-Hermine"
+      },
+      {
+        "code": "85233",
+        "nom": "Saint-Jean-de-Beugné"
+      }
+    ]
+  },
+  {
+    "code": "85289",
+    "nom": "Terval",
+    "anciennesCommunes": [
+      {
+        "code": "85037",
+        "nom": "Breuil-Barret"
+      },
+      {
+        "code": "85053",
+        "nom": "La Chapelle-aux-Lys"
+      },
+      {
+        "code": "85289",
+        "nom": "La Tardière"
+      }
+    ]
+  },
+  {
+    "code": "85292",
+    "nom": "Rives-du-Fougerais",
+    "anciennesCommunes": [
+      {
+        "code": "85041",
+        "nom": "Cezais"
+      },
+      {
+        "code": "85271",
+        "nom": "Saint-Sulpice-en-Pareds"
+      },
+      {
+        "code": "85292",
+        "nom": "Thouarsais-Bouildroux"
+      }
+    ]
+  },
+  {
+    "code": "85302",
+    "nom": "Chanverrie",
+    "anciennesCommunes": [
+      {
+        "code": "85048",
+        "nom": "Chambretaud"
+      },
+      {
+        "code": "85302",
+        "nom": "La Verrie"
+      }
+    ]
+  },
+  {
+    "code": "86019",
+    "nom": "Beaumont Saint-Cyr",
+    "anciennesCommunes": [
+      {
+        "code": "86019",
+        "nom": "Beaumont"
+      },
+      {
+        "code": "86219",
+        "nom": "Saint-Cyr"
+      }
+    ]
+  },
+  {
+    "code": "86053",
+    "nom": "Champigny en Rochereau",
+    "anciennesCommunes": [
+      {
+        "code": "86053",
+        "nom": "Champigny-le-Sec"
+      },
+      {
+        "code": "86208",
+        "nom": "Le Rochereau"
+      }
+    ]
+  },
+  {
+    "code": "86082",
+    "nom": "Valence-en-Poitou",
+    "anciennesCommunes": [
+      {
+        "code": "86043",
+        "nom": "Ceaux-en-Couhé"
+      },
+      {
+        "code": "86067",
+        "nom": "Châtillon"
+      },
+      {
+        "code": "86082",
+        "nom": "Couhé"
+      },
+      {
+        "code": "86188",
+        "nom": "Payré"
+      },
+      {
+        "code": "86278",
+        "nom": "Vaux"
+      }
+    ]
+  },
+  {
+    "code": "86115",
+    "nom": "Jaunay-Marigny",
+    "anciennesCommunes": [
+      {
+        "code": "86115",
+        "nom": "Jaunay-Clan"
+      },
+      {
+        "code": "86146",
+        "nom": "Marigny-Brizay"
+      }
+    ]
+  },
+  {
+    "code": "86123",
+    "nom": "Boivre-la-Vallée",
+    "anciennesCommunes": [
+      {
+        "code": "86021",
+        "nom": "Benassay"
+      },
+      {
+        "code": "86056",
+        "nom": "La Chapelle-Montreuil"
+      },
+      {
+        "code": "86123",
+        "nom": "Lavausseau"
+      },
+      {
+        "code": "86166",
+        "nom": "Montreuil-Bonnin"
+      }
+    ]
+  },
+  {
+    "code": "86233",
+    "nom": "Valdivienne",
+    "anciennesCommunes": [
+      {
+        "code": "86233",
+        "nom": "Valdivienne"
+      }
+    ]
+  },
+  {
+    "code": "86245",
+    "nom": "Senillé-Saint-Sauveur",
+    "anciennesCommunes": [
+      {
+        "code": "86245",
+        "nom": "Saint-Sauveur"
+      },
+      {
+        "code": "86259",
+        "nom": "Senillé"
+      }
+    ]
+  },
+  {
+    "code": "86247",
+    "nom": "Val-de-Comporté",
+    "anciennesCommunes": [
+      {
+        "code": "86231",
+        "nom": "Saint-Macoux"
+      },
+      {
+        "code": "86247",
+        "nom": "Saint-Saviol"
+      }
+    ]
+  },
+  {
+    "code": "86281",
+    "nom": "Saint-Martin-la-Pallu",
+    "anciennesCommunes": [
+      {
+        "code": "86030",
+        "nom": "Blaslay"
+      },
+      {
+        "code": "86060",
+        "nom": "Charrais"
+      },
+      {
+        "code": "86071",
+        "nom": "Cheneché"
+      },
+      {
+        "code": "86277",
+        "nom": "Varennes"
+      },
+      {
+        "code": "86281",
+        "nom": "Vendeuvre-du-Poitou"
+      }
+    ]
+  },
+  {
+    "code": "87028",
+    "nom": "Val-d'Oire-et-Gartempe",
+    "anciennesCommunes": [
+      {
+        "code": "87028",
+        "nom": "Bussière-Poitevine"
+      },
+      {
+        "code": "87055",
+        "nom": "Darnac"
+      },
+      {
+        "code": "87136",
+        "nom": "Saint-Barbant"
+      },
+      {
+        "code": "87196",
+        "nom": "Thiat"
+      }
+    ]
+  },
+  {
+    "code": "87085",
+    "nom": "Limoges",
+    "anciennesCommunes": [
+      {
+        "code": "87085",
+        "nom": "Limoges"
+      }
+    ]
+  },
+  {
+    "code": "87097",
+    "nom": "Val d'Issoire",
+    "anciennesCommunes": [
+      {
+        "code": "87026",
+        "nom": "Bussière-Boffy"
+      },
+      {
+        "code": "87097",
+        "nom": "Mézières-sur-Issoire"
+      }
+    ]
+  },
+  {
+    "code": "87128",
+    "nom": "Saint-Pardoux-le-Lac",
+    "anciennesCommunes": [
+      {
+        "code": "87128",
+        "nom": "Roussac"
+      },
+      {
+        "code": "87173",
+        "nom": "Saint-Pardoux"
+      },
+      {
+        "code": "87184",
+        "nom": "Saint-Symphorien-sur-Couze"
+      }
+    ]
+  },
+  {
+    "code": "88029",
+    "nom": "La Vôge-les-Bains",
+    "anciennesCommunes": [
+      {
+        "code": "88029",
+        "nom": "Bains-les-Bains"
+      },
+      {
+        "code": "88234",
+        "nom": "Harsault"
+      },
+      {
+        "code": "88235",
+        "nom": "Hautmougey"
+      }
+    ]
+  },
+  {
+    "code": "88176",
+    "nom": "Fontenoy-le-Château",
+    "anciennesCommunes": [
+      {
+        "code": "88176",
+        "nom": "Fontenoy-le-Château"
+      },
+      {
+        "code": "88282",
+        "nom": "Le Magny"
+      }
+    ]
+  },
+  {
+    "code": "88218",
+    "nom": "Granges-Aumontzey",
+    "anciennesCommunes": [
+      {
+        "code": "88018",
+        "nom": "Aumontzey"
+      },
+      {
+        "code": "88218",
+        "nom": "Granges-sur-Vologne"
+      }
+    ]
+  },
+  {
+    "code": "88321",
+    "nom": "Neufchâteau",
+    "anciennesCommunes": [
+      {
+        "code": "88321",
+        "nom": "Neufchâteau"
+      },
+      {
+        "code": "88393",
+        "nom": "Rollainville"
+      }
+    ]
+  },
+  {
+    "code": "88361",
+    "nom": "Provenchères-et-Colroy",
+    "anciennesCommunes": [
+      {
+        "code": "88112",
+        "nom": "Colroy-la-Grande"
+      },
+      {
+        "code": "88361",
+        "nom": "Provenchères-sur-Fave"
+      }
+    ]
+  },
+  {
+    "code": "88465",
+    "nom": "Thaon-les-Vosges",
+    "anciennesCommunes": [
+      {
+        "code": "88204",
+        "nom": "Girmont"
+      },
+      {
+        "code": "88337",
+        "nom": "Oncourt"
+      },
+      {
+        "code": "88465",
+        "nom": "Thaon-les-Vosges"
+      }
+    ]
+  },
+  {
+    "code": "88475",
+    "nom": "Tollaincourt",
+    "anciennesCommunes": [
+      {
+        "code": "88392",
+        "nom": "Rocourt"
+      },
+      {
+        "code": "88475",
+        "nom": "Tollaincourt"
+      }
+    ]
+  },
+  {
+    "code": "89003",
+    "nom": "Montholon",
+    "anciennesCommunes": [
+      {
+        "code": "89003",
+        "nom": "Aillant-sur-Tholon"
+      },
+      {
+        "code": "89078",
+        "nom": "Champvallon"
+      },
+      {
+        "code": "89473",
+        "nom": "Villiers-sur-Tholon"
+      },
+      {
+        "code": "89484",
+        "nom": "Volgré"
+      }
+    ]
+  },
+  {
+    "code": "89086",
+    "nom": "Charny Orée de Puisaye",
+    "anciennesCommunes": [
+      {
+        "code": "89070",
+        "nom": "Chambeugle"
+      },
+      {
+        "code": "89086",
+        "nom": "Charny"
+      },
+      {
+        "code": "89097",
+        "nom": "Chêne-Arnoult"
+      },
+      {
+        "code": "89103",
+        "nom": "Chevillon"
+      },
+      {
+        "code": "89138",
+        "nom": "Dicy"
+      },
+      {
+        "code": "89178",
+        "nom": "Fontenouilles"
+      },
+      {
+        "code": "89192",
+        "nom": "Grandchamp"
+      },
+      {
+        "code": "89241",
+        "nom": "Malicorne"
+      },
+      {
+        "code": "89243",
+        "nom": "Marchais-Beton"
+      },
+      {
+        "code": "89294",
+        "nom": "Perreux"
+      },
+      {
+        "code": "89317",
+        "nom": "Prunoy"
+      },
+      {
+        "code": "89343",
+        "nom": "Saint-Denis-sur-Ouanne"
+      },
+      {
+        "code": "89358",
+        "nom": "Saint-Martin-sur-Ouanne"
+      },
+      {
+        "code": "89454",
+        "nom": "Villefranche"
+      }
+    ]
+  },
+  {
+    "code": "89130",
+    "nom": "Deux Rivières",
+    "anciennesCommunes": [
+      {
+        "code": "89001",
+        "nom": "Accolay"
+      },
+      {
+        "code": "89130",
+        "nom": "Cravant"
+      }
+    ]
+  },
+  {
+    "code": "89196",
+    "nom": "Valravillon",
+    "anciennesCommunes": [
+      {
+        "code": "89196",
+        "nom": "Guerchy"
+      },
+      {
+        "code": "89213",
+        "nom": "Laduz"
+      },
+      {
+        "code": "89275",
+        "nom": "Neuilly"
+      },
+      {
+        "code": "89457",
+        "nom": "Villemer"
+      }
+    ]
+  },
+  {
+    "code": "89197",
+    "nom": "Guillon-Terre-Plaine",
+    "anciennesCommunes": [
+      {
+        "code": "89109",
+        "nom": "Cisery"
+      },
+      {
+        "code": "89197",
+        "nom": "Guillon"
+      },
+      {
+        "code": "89381",
+        "nom": "Sceaux"
+      },
+      {
+        "code": "89421",
+        "nom": "Trévilly"
+      },
+      {
+        "code": "89448",
+        "nom": "Vignes"
+      }
+    ]
+  },
+  {
+    "code": "89334",
+    "nom": "Le Val d'Ocre",
+    "anciennesCommunes": [
+      {
+        "code": "89334",
+        "nom": "Saint-Aubin-Château-Neuf"
+      },
+      {
+        "code": "89356",
+        "nom": "Saint-Martin-sur-Ocre"
+      }
+    ]
+  },
+  {
+    "code": "89388",
+    "nom": "Sépeaux-Saint Romain",
+    "anciennesCommunes": [
+      {
+        "code": "89366",
+        "nom": "Saint-Romain-le-Preux"
+      },
+      {
+        "code": "89388",
+        "nom": "Sépeaux"
+      }
+    ]
+  },
+  {
+    "code": "89405",
+    "nom": "Les Hauts de Forterre",
+    "anciennesCommunes": [
+      {
+        "code": "89174",
+        "nom": "Fontenailles"
+      },
+      {
+        "code": "89260",
+        "nom": "Molesmes"
+      },
+      {
+        "code": "89405",
+        "nom": "Taingy"
+      }
+    ]
+  },
+  {
+    "code": "89411",
+    "nom": "Les Vallées de la Vanne",
+    "anciennesCommunes": [
+      {
+        "code": "89107",
+        "nom": "Chigy"
+      },
+      {
+        "code": "89411",
+        "nom": "Theil-sur-Vanne"
+      },
+      {
+        "code": "89429",
+        "nom": "Vareilles"
+      }
+    ]
+  },
+  {
+    "code": "89420",
+    "nom": "Treigny-Perreuse-Sainte-Colombe",
+    "anciennesCommunes": [
+      {
+        "code": "89340",
+        "nom": "Sainte-Colombe-sur-Loing"
+      },
+      {
+        "code": "89420",
+        "nom": "Treigny"
+      }
+    ]
+  },
+  {
+    "code": "89441",
+    "nom": "Vermenton",
+    "anciennesCommunes": [
+      {
+        "code": "89330",
+        "nom": "Sacy"
+      },
+      {
+        "code": "89441",
+        "nom": "Vermenton"
+      }
+    ]
+  },
+  {
+    "code": "90068",
+    "nom": "Meroux-Moval",
+    "anciennesCommunes": [
+      {
+        "code": "90068",
+        "nom": "Meroux"
+      },
+      {
+        "code": "90073",
+        "nom": "Moval"
+      }
+    ]
+  },
+  {
+    "code": "91086",
+    "nom": "Bondoufle",
+    "anciennesCommunes": [
+      {
+        "code": "91086",
+        "nom": "Bondoufle"
+      }
+    ]
+  },
+  {
+    "code": "91228",
+    "nom": "Évry-Courcouronnes",
+    "anciennesCommunes": [
+      {
+        "code": "91182",
+        "nom": "Courcouronnes"
+      },
+      {
+        "code": "91228",
+        "nom": "Évry"
+      }
+    ]
+  },
+  {
+    "code": "91390",
+    "nom": "Le Mérévillois",
+    "anciennesCommunes": [
+      {
+        "code": "91222",
+        "nom": "Estouches"
+      },
+      {
+        "code": "91390",
+        "nom": "Méréville"
+      }
+    ]
+  },
+  {
+    "code": "93066",
+    "nom": "Saint-Denis",
+    "anciennesCommunes": [
+      {
+        "code": "93059",
+        "nom": "Pierrefitte-sur-Seine"
+      },
+      {
+        "code": "93066",
+        "nom": "Saint-Denis"
+      }
+    ]
+  },
+  {
+    "code": "93070",
+    "nom": "Saint-Ouen-sur-Seine",
+    "anciennesCommunes": [
+      {
+        "code": "93070",
+        "nom": "Saint-Ouen"
+      }
+    ]
+  },
+  {
+    "code": "95019",
+    "nom": "Arnouville",
+    "anciennesCommunes": [
+      {
+        "code": "95019",
+        "nom": "Arnouville-lès-Gonesse"
+      }
+    ]
+  },
+  {
+    "code": "95040",
+    "nom": "Avernes",
+    "anciennesCommunes": [
+      {
+        "code": "95040",
+        "nom": "Avernes"
+      },
+      {
+        "code": "95259",
+        "nom": "Gadancourt"
+      }
+    ]
+  },
+  {
+    "code": "95169",
+    "nom": "Commeny",
+    "anciennesCommunes": [
+      {
+        "code": "95169",
+        "nom": "Commeny"
+      },
+      {
+        "code": "95282",
+        "nom": "Gouzangrez"
+      }
+    ]
+  },
+  {
+    "code": "95306",
+    "nom": "Herblay-sur-Seine",
+    "anciennesCommunes": [
+      {
+        "code": "95306",
+        "nom": "Herblay"
+      }
+    ]
+  },
+  {
+    "code": "95308",
+    "nom": "Hérouville-en-Vexin",
+    "anciennesCommunes": [
+      {
+        "code": "95308",
+        "nom": "Hérouville"
       }
     ]
   }

--- a/scripts/update-communes-precedentes-by-chef-lieu.js
+++ b/scripts/update-communes-precedentes-by-chef-lieu.js
@@ -18,7 +18,6 @@ const getCommunesPrecedents = async (codeCommune, date) => {
   const url = `https://api.insee.fr/metadonnees/geo/commune/${codeCommune}/precedents${
     date ? `?date=${date}` : ''
   }`;
-  console.log(url);
   const response = await got(url, {
     headers: {
       accept: 'application/json',


### PR DESCRIPTION
## CONTEXT

Yoann a fait remarqué qu'une commune n'avait pas toutes ses communes précédentes sur mes-adresses: https://mattermost.incubateur.net/betagouv/pl/34mpiyk8yffupbdwc7e78511rr

Pour une communes qui avait fusionné 4 communes en 2016 et 3 communes en 2019 le route `https://api.insee.fr/metadonnees/geo/commune/50523/precedents` ne proposait que le 3 communes fusionné en 2019, il en manquait donc 4.

Cette PR permet grace a la query date de la route, de récupèrer les communes des précédentes fusions (après 2010)

<img width="394" height="701" alt="Capture d’écran 2025-08-04 à 12 17 21" src="https://github.com/user-attachments/assets/0d470270-66e5-49fd-a49d-c727ba026c7f" />
