### PR TITLE
feat: route admin to sync bal with ids ban and publish

### DIFF
--- a/apps/api/src/modules/admin/admin.controller.ts
+++ b/apps/api/src/modules/admin/admin.controller.ts
@@ -2,8 +2,10 @@ import {
   Body,
   Controller,
   Get,
+  HttpException,
   HttpStatus,
   Post,
+  Req,
   Res,
   UseGuards,
 } from '@nestjs/common';
@@ -23,17 +25,18 @@ import {
   ApiResponse,
   ApiExcludeEndpoint,
   ApiTags,
+  ApiParam,
 } from '@nestjs/swagger';
 import { BaseLocale } from '@/shared/entities/base_locale.entity';
 import { FusionCommunesDTO } from './dto/fusion_bases_locales.dto';
 import { AdminService } from './admin.service';
+import { CustomRequest } from '@/lib/types/request.type';
 
 @ApiTags('admin')
 @Controller('admin')
 export class AdminController {
   constructor(
     private baseLocaleService: BaseLocaleService,
-    private voieService: VoieService,
     private adminService: AdminService,
   ) {}
 
@@ -100,5 +103,34 @@ export class AdminController {
       await this.adminService.fusionCommunes(fusionCommunesDTO);
 
     res.status(HttpStatus.OK).json(result);
+  }
+
+  @Post('bases-locales/:baseLocaleId/sync-ids-ban-publish')
+  @ApiOperation({
+    summary: 'Synchro ids BAL with ids BAN and publish',
+    operationId: 'syncIdsBANPublish',
+  })
+  @ApiParam({ name: 'baseLocaleId', required: true, type: String })
+  @ApiResponse({ status: HttpStatus.CREATED, type: BaseLocale })
+  @ApiBearerAuth('admin-token')
+  @UseGuards(SuperAdminGuard)
+  async syncIdsBANPublish(@Req() req: CustomRequest, @Res() res: Response) {
+    try {
+      await this.baseLocaleService.syncIdsBAN(req.baseLocale);
+      const result = await this.baseLocaleService.forcePublish(
+        req.baseLocale.id,
+      );
+      if (!result.success) {
+        throw new HttpException(result.error, HttpStatus.PRECONDITION_FAILED);
+      }
+      const baseLocale = await this.baseLocaleService.findOneOrFail(
+        req.baseLocale.id,
+      );
+      res.status(HttpStatus.OK).json(baseLocale);
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    res.status(HttpStatus.NO_CONTENT).send();
   }
 }

--- a/apps/api/src/modules/admin/admin.controller.ts
+++ b/apps/api/src/modules/admin/admin.controller.ts
@@ -17,7 +17,6 @@ import * as intoStream from 'into-stream';
 import * as pumpify from 'pumpify';
 import { BaseLocaleService } from '../base_locale/base_locale.service';
 import { SuperAdminGuard } from '@/lib/guards/admin.guard';
-import { VoieService } from '../voie/voie.service';
 import {
   ApiBearerAuth,
   ApiBody,

--- a/apps/api/src/modules/admin/admin.module.ts
+++ b/apps/api/src/modules/admin/admin.module.ts
@@ -1,4 +1,9 @@
-import { Module, forwardRef } from '@nestjs/common';
+import {
+  MiddlewareConsumer,
+  Module,
+  RequestMethod,
+  forwardRef,
+} from '@nestjs/common';
 
 import { VoieModule } from '../voie/voie.module';
 import { BaseLocaleModule } from '../base_locale/base_locale.module';
@@ -7,6 +12,7 @@ import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { ToponymeModule } from '../toponyme/toponyme.module';
 import { NumeroModule } from '../numeros/numero.module';
+import { BaseLocaleMiddleware } from '../base_locale/base_locale.middleware';
 
 @Module({
   imports: [
@@ -19,4 +25,11 @@ import { NumeroModule } from '../numeros/numero.module';
   providers: [AdminService],
   controllers: [AdminController],
 })
-export class AdminModule {}
+export class AdminModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(BaseLocaleMiddleware).forRoutes({
+      path: 'admin/bases-locales/:baseLocaleId/sync-ids-ban-publish',
+      method: RequestMethod.POST,
+    });
+  }
+}

--- a/apps/api/src/modules/base_locale/base_locale.module.ts
+++ b/apps/api/src/modules/base_locale/base_locale.module.ts
@@ -18,6 +18,7 @@ import { BaseLocale } from '@/shared/entities/base_locale.entity';
 
 import { HabilitationModule } from '@/modules/base_locale/sub_modules/habilitation/habilitation.module';
 import { ExportCsvModule } from '@/modules/base_locale/sub_modules/export_csv/export_csv.module';
+import { ExportCsvModule as ExportCsvSharedModule } from '@/shared/modules/export_csv/export_csv.module';
 import { TilesModule } from '@/modules/base_locale/sub_modules/tiles/tiles.module';
 import { NumeroModule } from '@/modules/numeros/numero.module';
 import { VoieModule } from '@/modules/voie/voie.module';
@@ -41,6 +42,7 @@ import { QUEUE_NAME } from '@/shared/params/queue_name.const';
         removeOnFail: true,
       },
     }),
+    ExportCsvSharedModule,
     forwardRef(() => BanPlateformModule),
     forwardRef(() => HabilitationModule),
     forwardRef(() => ExportCsvModule),

--- a/apps/api/src/modules/base_locale/base_locale.service.ts
+++ b/apps/api/src/modules/base_locale/base_locale.service.ts
@@ -739,9 +739,12 @@ export class BaseLocaleService {
 
   async syncIdsBAN(baseLocale: BaseLocale) {
     const csvFile: string = await this.exportCsvService.exportToCsv(baseLocale);
-    const treeBAL = (await formattingBAL(Buffer.from(csvFile, 'utf8'), {
-      returnTree: true,
-    })) as BalTree;
+    const { tree: treeBAL } = (await formattingBAL(
+      Buffer.from(csvFile, 'utf8'),
+      {
+        withTree: true,
+      },
+    )) as { tree: BalTree; file: Buffer };
 
     for (const voies of Object.values(treeBAL.voies)) {
       if (voies.previous_id_ban_toponyme !== voies.id_ban_toponyme) {

--- a/apps/api/src/modules/base_locale/base_locale.service.ts
+++ b/apps/api/src/modules/base_locale/base_locale.service.ts
@@ -65,6 +65,9 @@ import { TaskTitle } from '@/shared/types/task.type';
 import { QUEUE_NAME } from '@/shared/params/queue_name.const';
 import { getEmailsMairie } from '@/lib/utils/annuaire-service-public';
 import { RecoverCommuneDTO } from './dto/recover_commune.dto';
+import { ExportCsvService } from '@/shared/modules/export_csv/export_csv.service';
+import { BalTree, formattingBAL } from 'formatting-bal';
+import { Numero } from '@/shared/entities/numero.entity';
 
 const KEY_POPULATE_BAL_ID = 'populateBalID';
 
@@ -85,6 +88,7 @@ export class BaseLocaleService {
     private populateService: PopulateService,
     @Inject(forwardRef(() => BanPlateformService))
     private banPlateformService: BanPlateformService,
+    private exportCsvService: ExportCsvService,
     private configService: ConfigService,
     private cacheService: CacheService,
     private readonly logger: Logger,
@@ -729,6 +733,44 @@ export class BaseLocaleService {
       throw error;
     } finally {
       await queueEvents.close();
+    }
+  }
+
+  async syncIdsBAN(baseLocale: BaseLocale) {
+    const csvFile: string = await this.exportCsvService.exportToCsv(baseLocale);
+    const treeBAL = (await formattingBAL(Buffer.from(csvFile, 'utf8'), {
+      returnTree: true,
+    })) as BalTree;
+
+    for (const voies of Object.values(treeBAL.voies)) {
+      if (voies.previous_id_ban_toponyme !== voies.id_ban_toponyme) {
+        await this.basesLocalesRepository
+          .createQueryBuilder('voies')
+          .update(Voie)
+          .set({
+            banId: voies.id_ban_toponyme,
+          })
+          .where({
+            banId: voies.previous_id_ban_toponyme,
+            balId: baseLocale.id,
+          })
+          .execute();
+      }
+      for (const numero of Object.values(voies.numeros)) {
+        if (numero.previous_id_ban_adresse !== numero.id_ban_adresse) {
+          await this.basesLocalesRepository
+            .createQueryBuilder('numeros')
+            .update(Numero)
+            .set({
+              banId: numero.id_ban_adresse,
+            })
+            .where({
+              banId: numero.previous_id_ban_adresse,
+              balId: baseLocale.id,
+            })
+            .execute();
+        }
+      }
     }
   }
 

--- a/apps/api/src/modules/base_locale/base_locale.service.ts
+++ b/apps/api/src/modules/base_locale/base_locale.service.ts
@@ -66,7 +66,7 @@ import { QUEUE_NAME } from '@/shared/params/queue_name.const';
 import { getEmailsMairie } from '@/lib/utils/annuaire-service-public';
 import { RecoverCommuneDTO } from './dto/recover_commune.dto';
 import { ExportCsvService } from '@/shared/modules/export_csv/export_csv.service';
-import { BalTree, formattingBAL } from 'formatting-bal';
+import { BalTree, formatterBAL } from '@ban-team/formatter-bal';
 import { Numero } from '@/shared/entities/numero.entity';
 
 const KEY_POPULATE_BAL_ID = 'populateBalID';
@@ -739,7 +739,7 @@ export class BaseLocaleService {
 
   async syncIdsBAN(baseLocale: BaseLocale) {
     const csvFile: string = await this.exportCsvService.exportToCsv(baseLocale);
-    const { tree: treeBAL } = (await formattingBAL(
+    const { tree: treeBAL } = (await formatterBAL(
       Buffer.from(csvFile, 'utf8'),
       {
         withTree: true,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "generate:openapi:signalement": "openapi --input http://localhost:5005/api-json --output ./libs/shared/src/openapi-signalement"
   },
   "dependencies": {
+    "formatting-bal": "file:../formatting-bal",
     "@aws-sdk/client-s3": "^3.787.0",
     "@ban-team/adresses-util": "^0.9.0",
     "@ban-team/shared-data": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "generate:openapi:signalement": "openapi --input http://localhost:5005/api-json --output ./libs/shared/src/openapi-signalement"
   },
   "dependencies": {
-    "formatting-bal": "file:../formatting-bal",
+    "@ban-team/formatter-bal": "^0.1.1",
     "@aws-sdk/client-s3": "^3.787.0",
     "@ban-team/adresses-util": "^0.9.0",
     "@ban-team/shared-data": "^1.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5770,6 +5770,11 @@ date-fns@^2.29.3, date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 date-time@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/date-time/-/date-time-3.1.0.tgz#0d1e934d170579f481ed8df1e2b8ff70ee845e1e"
@@ -6838,6 +6843,17 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+"formatting-bal@file:../formatting-bal":
+  version "0.1.0"
+  dependencies:
+    "@ban-team/adresses-util" "^0.9.0"
+    chardet "^1.4.0"
+    date-fns "^4.1.0"
+    file-type "^12.4.2"
+    iconv-lite "^0.6.3"
+    papaparse "^5.3.2"
+    yargs "^17.5.1"
 
 formidable@^2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,6 +1024,19 @@
     talisman "^1.1.4"
     written-number "^0.9.1"
 
+"@ban-team/formatter-bal@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@ban-team/formatter-bal/-/formatter-bal-0.1.1.tgz#1ebc83a99a0d21f6e72e6e9a73747f44f98a2a68"
+  integrity sha512-BsqvtBY5x1d0ypjdQJMpComa+oy5yYcc7HQNxXcQ75YUmmNbZl9gI2tjY7m6SSdFuy9p6/bzKjUnOjeWWM+w1w==
+  dependencies:
+    "@ban-team/adresses-util" "^0.9.0"
+    chardet "^1.4.0"
+    date-fns "^4.1.0"
+    file-type "^12.4.2"
+    iconv-lite "^0.6.3"
+    papaparse "^5.3.2"
+    yargs "^17.5.1"
+
 "@ban-team/shared-data@^1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.4.3.tgz#b8868d739dde7b6bb01af5a65221bbf0d81c7c25"
@@ -6843,17 +6856,6 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
-
-"formatting-bal@file:../formatting-bal":
-  version "0.1.0"
-  dependencies:
-    "@ban-team/adresses-util" "^0.9.0"
-    chardet "^1.4.0"
-    date-fns "^4.1.0"
-    file-type "^12.4.2"
-    iconv-lite "^0.6.3"
-    papaparse "^5.3.2"
-    yargs "^17.5.1"
 
 formidable@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## CONTEXT

Intégration de formatted-bal, pour synchroniser les BAL de mes-adresses avec les identifiants BAN via une route admin `/bases-locales/:baseLocaleId/sync-ids-ban-publish`