### PR TITLE
fix: bug bal conflict with itself

### DIFF
--- a/apps/cron/src/modules/task/tasks/sync_outdated.task.ts
+++ b/apps/cron/src/modules/task/tasks/sync_outdated.task.ts
@@ -39,11 +39,14 @@ export class SyncOutdatedTask implements Task {
 
     for (const bal of bals) {
       try {
-        this.logger.log(`Syncing BAL : ${bal.id}`, SyncOutdatedTask.name);
+        this.logger.log(
+          `Syncing BAL : ${bal.id} pour la commune ${bal.commune}`,
+          SyncOutdatedTask.name,
+        );
         await this.publicationService.exec(bal.id);
       } catch (error) {
         this.logger.error(
-          `Unable to sync BAL : ${bal.id}`,
+          `Unable to sync BAL : ${bal.id} pour la commune ${bal.commune}`,
           error,
           SyncOutdatedTask.name,
         );

--- a/libs/shared/src/modules/api_depot/api_depot.service.ts
+++ b/libs/shared/src/modules/api_depot/api_depot.service.ts
@@ -181,11 +181,18 @@ export class ApiDepotService {
         HttpStatus.EXPECTATION_FAILED,
       );
     }
-    const publishedRevision: Revision = await this.publishRevision(
-      computedRevision.id,
-      habilitationId,
-    );
-    return publishedRevision;
+    try {
+      return await this.publishRevision(computedRevision.id, habilitationId);
+    } catch (error) {
+      // En cas d'erreur réseau, la révision a peut-être été publiée côté api-depot
+      // malgré l'échec de la réponse HTTP. On vérifie en comparant l'ID de la
+      // révision courante avec celui qu'on vient de soumettre.
+      const currentRevision = await this.getCurrentRevision(codeCommune);
+      if (currentRevision?.id === computedRevision.id) {
+        return currentRevision;
+      }
+      throw error;
+    }
   }
 
   public async getCurrentRevision(codeCommune: string): Promise<Revision> {

--- a/libs/shared/src/modules/api_depot/api_depot.service.ts
+++ b/libs/shared/src/modules/api_depot/api_depot.service.ts
@@ -184,6 +184,11 @@ export class ApiDepotService {
     try {
       return await this.publishRevision(computedRevision.id, habilitationId);
     } catch (error) {
+      this.logger.warn(
+        `Error publishRevision : ${balId} pour la commune ${codeCommune}`,
+        error,
+        ApiDepotService.name,
+      );
       // En cas d'erreur réseau, la révision a peut-être été publiée côté api-depot
       // malgré l'échec de la réponse HTTP. On vérifie en comparant l'ID de la
       // révision courante avec celui qu'on vient de soumettre.

--- a/libs/shared/src/modules/api_depot/api_depot.service.ts
+++ b/libs/shared/src/modules/api_depot/api_depot.service.ts
@@ -193,6 +193,12 @@ export class ApiDepotService {
       // malgré l'échec de la réponse HTTP. On vérifie en comparant l'ID de la
       // révision courante avec celui qu'on vient de soumettre.
       const currentRevision = await this.getCurrentRevision(codeCommune);
+      this.logger.warn(
+        `Error publishRevision : currentRevision ${JSON.stringify(
+          currentRevision,
+        )}`,
+        ApiDepotService.name,
+      );
       if (currentRevision?.id === computedRevision.id) {
         return currentRevision;
       }

--- a/libs/shared/src/modules/publication/publication.service.ts
+++ b/libs/shared/src/modules/publication/publication.service.ts
@@ -161,8 +161,8 @@ export class PublicationService {
         return this.markAsSynced(baseLocale, publishedRevision.id);
       }
 
-      // On marque le sync de la BAL en published
-      return this.markAsSynced(baseLocale, sync.lastUploadedRevisionId);
+      // On marque le sync de la BAL en published avec la révision courante de l'api-depot
+      return this.markAsSynced(baseLocale, currentRevision.id);
     }
 
     return this.basesLocalesRepository.findOneBy({ id: balId });


### PR DESCRIPTION
## CONTEXT

Depuis le début certaine BAL sont en conflit avec elle même:
Le `sync.lastUploadedRevisionId` est celui de l'avant dernière révision et non celui de la revision courante, ce qui bloque le processus

## RECHERCHE

`publishNewRevision` fait un POST HTTP à l'api-depot. L'api-depot publie la nouvelle révision avec succès. Mais la réponse HTTP revient avec une erreur transitoire (timeout réseau). Axios remonte une exception, markAsSynced n'est jamais appelé. lastUploadedRevisionId reste sur l'id de l'ancienne révision.

## PREUVE

Pour la BAL de Ahun (23001) https://bal-admin.adresse.data.gouv.fr/communes/23001
Une BAL en conflit avec elle même le 11 mars

On peut voir dans le log qu'il y a eu un forcePublish le 11 mars
<img width="1562" height="211" alt="Capture d’écran 2026-05-20 à 14 57 01" src="https://github.com/user-attachments/assets/dfa35469-f473-4507-aea9-9999ab2afe49" />

Mais que ce dernier a échoué (mais la révision bien créé)
<img width="1563" height="252" alt="Capture d’écran 2026-05-20 à 14 57 21" src="https://github.com/user-attachments/assets/7d32d5d9-7560-4566-a452-e0b8e2dd5528" />

Et la requète coté api-depot a prit une bonne minute -> le timeout est fort probable
<img width="1583" height="744" alt="Capture d’écran 2026-05-20 à 14 57 55" src="https://github.com/user-attachments/assets/ede4b98b-9a5e-48aa-83c8-02b847fad9af" />

## CORRECTION

On enveloppe publishRevision dans un try/catch. En cas d'erreur, on appelle immédiatement getCurrentRevision et on compare l'ID de la révision courante avec computedRevision.id (qu'on connaît depuis l'étape computeRevision). Si c'est la même, la publication a réussi côté api-depot — seule la réponse a échoué. On retourne la révision et markAsSynced s'exécute normalement.